### PR TITLE
V3/turbine sort

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -35,8 +35,7 @@ jobs:
         # -rA displays the captured output for all tests after they're run
         # See the docs: https://doc.pytest.org/en/latest/reference/reference.html#command-line-flags
         pytest -rA tests/  --ignore tests/ignore --ignore tests/reg_tests
-        pytest -rA tests/reg_tests/jensen_jimenez_regression_test.py -k tandem
-        pytest -rA tests/reg_tests/jensen_jimenez_regression_test.py -k yaw
+        pytest -rA tests/reg_tests/jensen_jimenez_regression_test.py
     - name: Generate coverage report
       # Run these tests on unit tests only so that we avoid inflating our code
       # coverage through the regression tests

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -38,7 +38,7 @@ from . import (
     wake_combination,
 )
 from .farm import Farm
-from .grid import Grid, TurbineGrid, FlowFieldGrid
+from .grid import Grid, TurbineGrid #, FlowFieldGrid
 from .floris import Floris
 from .turbine import Turbine
 from .base_class import BaseClass

--- a/src/farm.py
+++ b/src/farm.py
@@ -212,6 +212,8 @@ class Farm(FromDictMixin):
             np.ndarray: The index order for retrieving data from `data_array` or any
                 other farm object.
         """
+        # TODO: This should live on the Grid since that's where the
+        # rotated coordinates are stored
 
         if by == "x":
             return np.argsort(self.layout_x)
@@ -223,3 +225,7 @@ class Farm(FromDictMixin):
     @property
     def n_turbines(self):
         return len(self.layout_x)
+
+    @property
+    def reference_turbine_diameter(self):
+        return self.rotor_diameter[0, 0, 0]

--- a/src/farm.py
+++ b/src/farm.py
@@ -219,3 +219,7 @@ class Farm(FromDictMixin):
             return np.argsort(self.layout_y)
         else:
             raise ValueError("`by` must be set to one of 'x' or 'y'!")
+
+    @property
+    def n_turbines(self):
+        return len(self.layout_x)

--- a/src/floris.py
+++ b/src/floris.py
@@ -14,7 +14,6 @@
 
 
 import json
-import pickle
 
 import src.logging_manager as logging_manager
 

--- a/src/floris.py
+++ b/src/floris.py
@@ -115,7 +115,7 @@ class Floris(logging_manager.LoggerBase):
         sequential_solver(self.farm, self.flow_field, grid)
 
         grid.finalize()
-        self.flow_field.finalize(grid.unsorted_indeces)
+        self.flow_field.finalize(grid.unsorted_indices)
 
     # Utility functions
 

--- a/src/floris.py
+++ b/src/floris.py
@@ -91,10 +91,30 @@ class Floris(logging_manager.LoggerBase):
         )
         self.flow_field = FlowField(farm_dict)
 
-    def go(self):
+    def annual_energy_production(self, wind_rose):
+        # self.steady_state_atmospheric_condition()
+        pass
+
+    def steady_state_atmospheric_condition(self):
+
+        # <<interface>>
+        # Initialize grid and field quanitities
+        grid = TurbineGrid(
+            self.farm.coordinates,
+            self.farm.reference_turbine_diameter,
+            self.flow_field.wind_directions,
+            self.flow_field.wind_speeds,
+            5,
+        )
+
+        self.flow_field.initialize_velocity_field(grid)
+
         # <<interface>>
         # JensenVelocityDeficit.solver(self.farm, self.flow_field)
-        sequential_solver(self.farm, self.flow_field)
+        sequential_solver(self.farm, self.flow_field, grid)
+
+        grid.finalize()
+        self.flow_field.finalize(grid.unsorted_indeces)
 
     # Utility functions
 

--- a/src/floris.py
+++ b/src/floris.py
@@ -106,6 +106,7 @@ class Floris(logging_manager.LoggerBase):
             self.flow_field.wind_speeds,
             5,
         )
+        # TODO: where do we pass in grid_resolution? Hardcoded to 5 above.
 
         self.flow_field.initialize_velocity_field(grid)
 

--- a/src/flow_field.py
+++ b/src/flow_field.py
@@ -25,7 +25,6 @@ class FlowField:
         self.wind_speeds = np.array(input_dictionary["wind_speeds"])
         self.wind_directions = np.array(input_dictionary["wind_directions"])
         self.reference_wind_height = input_dictionary["reference_wind_height"]
-        self.reference_turbine_diameter = input_dictionary["reference_turbine_diameter"]
         self.air_density = input_dictionary["air_density"]
 
     def initialize_velocity_field(self, grid: Grid) -> None:

--- a/src/flow_field.py
+++ b/src/flow_field.py
@@ -46,6 +46,22 @@ class FlowField:
         self.v = self.v_initial.copy()
         self.w = self.w_initial.copy()
 
+    def finalize(self, unsorted_indeces):
+        n_wind_directions = np.shape(self.u)[0]
+        n_turbines = np.shape(self.u)[2]
+
+        _u = np.zeros_like(self.u)
+        _v = np.zeros_like(self.v)
+        _w = np.zeros_like(self.w)
+        for i in range(n_wind_directions):
+            for j in range(n_turbines):
+                _u[i, :, j] = self.u[i, :, unsorted_indeces[i, j]]
+                _v[i, :, j] = self.v[i, :, unsorted_indeces[i, j]]
+                _w[i, :, j] = self.w[i, :, unsorted_indeces[i, j]]
+        self.u = _u
+        self.v = _v
+        self.w = _w
+
     @property
     def n_wind_speeds(self) -> int:
         return len(self.wind_speeds)

--- a/src/flow_field.py
+++ b/src/flow_field.py
@@ -47,9 +47,9 @@ class FlowField:
         self.w = self.w_initial.copy()
 
     def finalize(self, unsorted_indices):
-        self.u = np.take_along_axis(self.u, self.unsorted_indices, axis=2)
-        self.v = np.take_along_axis(self.v, self.unsorted_indices, axis=2)
-        self.w = np.take_along_axis(self.w, self.unsorted_indices, axis=2)
+        self.u = np.take_along_axis(self.u, unsorted_indices, axis=2)
+        self.v = np.take_along_axis(self.v, unsorted_indices, axis=2)
+        self.w = np.take_along_axis(self.w, unsorted_indices, axis=2)
 
     @property
     def n_wind_speeds(self) -> int:

--- a/src/flow_field.py
+++ b/src/flow_field.py
@@ -46,21 +46,10 @@ class FlowField:
         self.v = self.v_initial.copy()
         self.w = self.w_initial.copy()
 
-    def finalize(self, unsorted_indeces):
-        n_wind_directions = np.shape(self.u)[0]
-        n_turbines = np.shape(self.u)[2]
-
-        _u = np.zeros_like(self.u)
-        _v = np.zeros_like(self.v)
-        _w = np.zeros_like(self.w)
-        for i in range(n_wind_directions):
-            for j in range(n_turbines):
-                _u[i, :, j] = self.u[i, :, unsorted_indeces[i, j]]
-                _v[i, :, j] = self.v[i, :, unsorted_indeces[i, j]]
-                _w[i, :, j] = self.w[i, :, unsorted_indeces[i, j]]
-        self.u = _u
-        self.v = _v
-        self.w = _w
+    def finalize(self, unsorted_indices):
+        self.u = np.take_along_axis(self.u, self.unsorted_indices, axis=2)
+        self.v = np.take_along_axis(self.v, self.unsorted_indices, axis=2)
+        self.w = np.take_along_axis(self.w, self.unsorted_indices, axis=2)
 
     @property
     def n_wind_speeds(self) -> int:

--- a/src/grid.py
+++ b/src/grid.py
@@ -218,61 +218,61 @@ class TurbineGrid(Grid):
         self.y = _y
         self.z = _z
 
-class FlowFieldGrid(Grid):
-    """
-    Primarily used by the Curl model and for visualization
-    """
+# class FlowFieldGrid(Grid):
+#     """
+#     Primarily used by the Curl model and for visualization
+#     """
 
-    def __init__(
-        self,
-        turbine_coordinates: List[Vec3],
-        reference_turbine_diameter: float,
-        reference_wind_height: float,
-        grid_resolution: Vec3,
-    ) -> None:
+#     def __init__(
+#         self,
+#         turbine_coordinates: List[Vec3],
+#         reference_turbine_diameter: float,
+#         reference_wind_height: float,
+#         grid_resolution: Vec3,
+#     ) -> None:
 
-        # the x,y points are a regular grid based on given domain bounds
+#         # the x,y points are a regular grid based on given domain bounds
 
-        super().__init__(
-            turbine_coordinates,
-            reference_turbine_diameter,
-            grid_resolution,
-        )
+#         super().__init__(
+#             turbine_coordinates,
+#             reference_turbine_diameter,
+#             grid_resolution,
+#         )
 
-        self.set_bounds()
-        self.set_grid()
+#         self.set_bounds()
+#         self.set_grid()
 
-    def set_bounds(self) -> None:
-        # TODO: Should this be called "compute_bounds?"
-        #   anything set_ could require an argument to set a value
-        #   other functions that set variables based on previous inputs could be "compute_"
-        #   anything that returns values, even if they are computed on the fly, could be get_ (instead of @property)
-        """
-        Calculates the domain bounds for the current wake model. The bounds
-        are calculated based on preset extents from the
-        given layout. The bounds consist of the minimum and maximum values
-        in the x-, y-, and z-directions.
+#     def set_bounds(self) -> None:
+#         # TODO: Should this be called "compute_bounds?"
+#         #   anything set_ could require an argument to set a value
+#         #   other functions that set variables based on previous inputs could be "compute_"
+#         #   anything that returns values, even if they are computed on the fly, could be get_ (instead of @property)
+#         """
+#         Calculates the domain bounds for the current wake model. The bounds
+#         are calculated based on preset extents from the
+#         given layout. The bounds consist of the minimum and maximum values
+#         in the x-, y-, and z-directions.
 
-        If the Curl model is used, the predefined bounds are always set.
-        """
-        # For the curl model, bounds are hard coded
-        coords = self.turbine_coordinates
-        x = [coord.x1 for coord in coords]
-        y = [coord.x2 for coord in coords]
-        eps = 0.1
-        self.xmin = min(x) - 2 * self.reference_turbine_diameter
-        self.xmax = max(x) + 10 * self.reference_turbine_diameter
-        self.ymin = min(y) - 2 * self.reference_turbine_diameter
-        self.ymax = max(y) + 2 * self.reference_turbine_diameter
-        self.zmin = 0 + eps
-        self.zmax = 6 * self.reference_wind_height
+#         If the Curl model is used, the predefined bounds are always set.
+#         """
+#         # For the curl model, bounds are hard coded
+#         coords = self.turbine_coordinates
+#         x = [coord.x1 for coord in coords]
+#         y = [coord.x2 for coord in coords]
+#         eps = 0.1
+#         self.xmin = min(x) - 2 * self.reference_turbine_diameter
+#         self.xmax = max(x) + 10 * self.reference_turbine_diameter
+#         self.ymin = min(y) - 2 * self.reference_turbine_diameter
+#         self.ymax = max(y) + 2 * self.reference_turbine_diameter
+#         self.zmin = 0 + eps
+#         self.zmax = 6 * self.reference_wind_height
 
-    def set_grid(self) -> None:
-        """
-        Create a structured grid for the entire flow field domain.
-        resolution: Vec3
-        """
-        x_points = np.linspace(self.xmin, self.xmax, int(self.grid_resolution.x1))
-        y_points = np.linspace(self.ymin, self.ymax, int(self.grid_resolution.x2))
-        z_points = np.linspace(self.zmin, self.zmax, int(self.grid_resolution.x3))
-        self.x, self.y, self.z = np.meshgrid(x_points, y_points, z_points, indexing="ij")
+#     def set_grid(self) -> None:
+#         """
+#         Create a structured grid for the entire flow field domain.
+#         resolution: Vec3
+#         """
+#         x_points = np.linspace(self.xmin, self.xmax, int(self.grid_resolution.x1))
+#         y_points = np.linspace(self.ymin, self.ymax, int(self.grid_resolution.x2))
+#         z_points = np.linspace(self.zmin, self.zmax, int(self.grid_resolution.x3))
+#         self.x, self.y, self.z = np.meshgrid(x_points, y_points, z_points, indexing="ij")

--- a/src/grid.py
+++ b/src/grid.py
@@ -12,7 +12,6 @@ class Grid(ABC):
         self,
         turbine_coordinates: List[Vec3],
         reference_turbine_diameter: float,
-        reference_wind_height: float,
         grid_resolution: int,
     ) -> None:
         """
@@ -28,7 +27,6 @@ class Grid(ABC):
         """
         self.turbine_coordinates: List[Vec3] = turbine_coordinates
         self.reference_turbine_diameter: float = reference_turbine_diameter
-        self.reference_wind_height: float = reference_wind_height
         self.grid_resolution: int = grid_resolution
         # x are the locations in space in the primary direction (typically the direction of the wind)
         # y are the locations in space in the lateral direction
@@ -104,15 +102,15 @@ class TurbineGrid(Grid):
         self,
         turbine_coordinates: List[Vec3],
         reference_turbine_diameter: float,
-        reference_wind_height: float,
         grid_resolution: int,
     ) -> None:
         # establishes a data structure with grid on each turbine
         # the x,y,z points here are the grid points on the turbine swept area
+        # TODO: should reference_turbine_diameter be here or in Farm? currently in both.
+        #       Both may be fine, they could be different maybe.
         super().__init__(
             turbine_coordinates,
             reference_turbine_diameter,
-            reference_wind_height,
             grid_resolution,
         )
         self.set_grid()
@@ -219,7 +217,6 @@ class FlowFieldGrid(Grid):
         super().__init__(
             turbine_coordinates,
             reference_turbine_diameter,
-            reference_wind_height,
             grid_resolution,
         )
 

--- a/src/grid.py
+++ b/src/grid.py
@@ -182,7 +182,7 @@ class TurbineGrid(Grid):
 
         # Calculate the radial distance from the center of the turbine rotor
         disc_grid = np.linspace(-1 * disc_area_radius, disc_area_radius, self.grid_resolution)
-        template_rotor = template_grid * ( disc_grid * np.ones((5,5)) )
+        template_rotor = template_grid * ( disc_grid * np.ones((self.grid_resolution, self.grid_resolution)) )
 
         _x = x_coord_rotated[:, :, :, None, None] * template_grid
         _y = y_coord_rotated[:, :, :, None, None] + template_rotor

--- a/src/grid.py
+++ b/src/grid.py
@@ -222,8 +222,8 @@ class TurbineGrid(Grid):
         for i in range(n_wind_directions):
             for j in range(n_turbines):
                 _x[i, :, j] = self.x[i, :, self.unsorted_indeces[i, j]]
-                _y[i, :, j] = self.x[i, :, self.unsorted_indeces[i, j]]
-                _z[i, :, j] = self.x[i, :, self.unsorted_indeces[i, j]]
+                _y[i, :, j] = self.y[i, :, self.unsorted_indeces[i, j]]
+                _z[i, :, j] = self.z[i, :, self.unsorted_indeces[i, j]]
         self.x = _x
         self.y = _y
         self.z = _z

--- a/src/grid.py
+++ b/src/grid.py
@@ -202,6 +202,22 @@ class TurbineGrid(Grid):
                 self.y[i, :, j] = _y[i, :, self.sorted_indeces[i, j]]
                 self.z[i, :, j] = _z[i, :, self.sorted_indeces[i, j]]
 
+    def finalize(self):
+        n_wind_directions = np.shape(self.x)[0]
+        n_turbines = np.shape(self.x)[2]
+
+        _x = np.zeros_like(self.x)
+        _y = np.zeros_like(self.y)
+        _z = np.zeros_like(self.z)
+        for i in range(n_wind_directions):
+            for j in range(n_turbines):
+                _x[i, :, j] = self.x[i, :, self.unsorted_indeces[i, j]]
+                _y[i, :, j] = self.x[i, :, self.unsorted_indeces[i, j]]
+                _z[i, :, j] = self.x[i, :, self.unsorted_indeces[i, j]]
+        self.x = _x
+        self.y = _y
+        self.z = _z
+
 class FlowFieldGrid(Grid):
     """
     Primarily used by the Curl model and for visualization

--- a/src/grid.py
+++ b/src/grid.py
@@ -151,7 +151,7 @@ class TurbineGrid(Grid):
 
         # Calculate the difference in given wind direction from 270 / West
         wind_deviation_from_west = -1 * ((wind_directions - 270) % 360 + 360) % 360
-        wind_deviation_from_west = np.reshape(wind_deviation_from_west, (n_wind_directions, 1, 1) )
+        wind_deviation_from_west = np.reshape(wind_deviation_from_west, (n_wind_directions, 1, 1))
 
         # Construct the arrays storing the turbine locations
         x_coordinates = np.array([c.x1 for c in self.turbine_coordinates])
@@ -168,9 +168,16 @@ class TurbineGrid(Grid):
         # Rotate turbine coordinates about the center
         x_coord_offset = x_coordinates - x_center_of_rotation
         y_coord_offset = y_coordinates - y_center_of_rotation
-        x_coord_rotated = x_coord_offset * cosd(wind_deviation_from_west) - y_coord_offset * sind(wind_deviation_from_west) + x_center_of_rotation
-        y_coord_rotated = x_coord_offset * sind(wind_deviation_from_west) + y_coord_offset * cosd(wind_deviation_from_west) + y_center_of_rotation
-
+        x_coord_rotated = (
+            x_coord_offset * cosd(wind_deviation_from_west)
+            - y_coord_offset * sind(wind_deviation_from_west)
+            + x_center_of_rotation
+        )
+        y_coord_rotated = (
+            x_coord_offset * sind(wind_deviation_from_west)
+            + y_coord_offset * cosd(wind_deviation_from_west)
+            + y_center_of_rotation
+        )
 
         # -   **rloc** (*float, optional): A value, from 0 to 1, that determines
         #         the width/height of the grid of points on the rotor as a ratio of
@@ -180,11 +187,13 @@ class TurbineGrid(Grid):
         # Create the data for the turbine grids
         radius_ratio = 0.5
         disc_area_radius = radius_ratio * self.reference_turbine_diameter / 2
-        template_grid = np.ones((n_wind_directions, n_wind_speeds, n_turbines, self.grid_resolution, self.grid_resolution))
+        template_grid = np.ones(
+            (n_wind_directions, n_wind_speeds, n_turbines, self.grid_resolution, self.grid_resolution)
+        )
 
         # Calculate the radial distance from the center of the turbine rotor
         disc_grid = np.linspace(-1 * disc_area_radius, disc_area_radius, self.grid_resolution)
-        template_rotor = template_grid * ( disc_grid * np.ones((self.grid_resolution, self.grid_resolution)) )
+        template_rotor = template_grid * (disc_grid * np.ones((self.grid_resolution, self.grid_resolution)))
 
         # Construct the turbine grids
         # Here, they are already rotated to the correct orientation for each wind direction
@@ -194,11 +203,11 @@ class TurbineGrid(Grid):
 
         # Sort the turbines at each wind direction
 
-        # Get the sorted indeces for the x coordinates. These are the indeces
+        # Get the sorted indices for the x coordinates. These are the indices
         # to sort the turbines from upstream to downstream for all wind directions.
-        # Also, store the indeces to sort them back for when the calculation finishes.
-        self.sorted_indeces = np.array([np.argsort(_x[i, 0, :, 0, 0]) for i in range(n_wind_directions)])
-        self.unsorted_indeces = np.array([np.argsort(self.sorted_indeces[i]) for i in range(n_wind_directions)])
+        # Also, store the indices to sort them back for when the calculation finishes.
+        self.sorted_indices = np.array([np.argsort(_x[i, 0, :, 0, 0]) for i in range(n_wind_directions)])
+        self.unsorted_indices = np.array([np.argsort(self.sorted_indices[i]) for i in range(n_wind_directions)])
 
         # Put the turbines into the final arrays in their sorted order
         self.x = np.zeros_like(_x)
@@ -206,9 +215,9 @@ class TurbineGrid(Grid):
         self.z = np.zeros_like(_z)
         for i in range(n_wind_directions):
             for j in range(n_turbines):
-                self.x[i, :, j] = _x[i, :, self.sorted_indeces[i, j]]
-                self.y[i, :, j] = _y[i, :, self.sorted_indeces[i, j]]
-                self.z[i, :, j] = _z[i, :, self.sorted_indeces[i, j]]
+                self.x[i, :, j] = _x[i, :, self.sorted_indices[i, j]]
+                self.y[i, :, j] = _y[i, :, self.sorted_indices[i, j]]
+                self.z[i, :, j] = _z[i, :, self.sorted_indices[i, j]]
 
     def finalize(self):
         n_wind_directions = np.shape(self.x)[0]
@@ -221,12 +230,13 @@ class TurbineGrid(Grid):
         _z = np.zeros_like(self.z)
         for i in range(n_wind_directions):
             for j in range(n_turbines):
-                _x[i, :, j] = self.x[i, :, self.unsorted_indeces[i, j]]
-                _y[i, :, j] = self.y[i, :, self.unsorted_indeces[i, j]]
-                _z[i, :, j] = self.z[i, :, self.unsorted_indeces[i, j]]
+                _x[i, :, j] = self.x[i, :, self.unsorted_indices[i, j]]
+                _y[i, :, j] = self.y[i, :, self.unsorted_indices[i, j]]
+                _z[i, :, j] = self.z[i, :, self.unsorted_indices[i, j]]
         self.x = _x
         self.y = _y
         self.z = _z
+
 
 # class FlowFieldGrid(Grid):
 #     """

--- a/src/grid.py
+++ b/src/grid.py
@@ -206,36 +206,20 @@ class TurbineGrid(Grid):
         # Get the sorted indices for the x coordinates. These are the indices
         # to sort the turbines from upstream to downstream for all wind directions.
         # Also, store the indices to sort them back for when the calculation finishes.
-        self.sorted_indices = np.array([np.argsort(_x[i, 0, :, 0, 0]) for i in range(n_wind_directions)])
-        self.unsorted_indices = np.array([np.argsort(self.sorted_indices[i]) for i in range(n_wind_directions)])
+        self.sorted_indices = _x.argsort(axis=2)
+        self.unsorted_indices = self.sorted_indices.argsort(axis=2)
 
         # Put the turbines into the final arrays in their sorted order
-        self.x = np.zeros_like(_x)
-        self.y = np.zeros_like(_y)
-        self.z = np.zeros_like(_z)
-        for i in range(n_wind_directions):
-            for j in range(n_turbines):
-                self.x[i, :, j] = _x[i, :, self.sorted_indices[i, j]]
-                self.y[i, :, j] = _y[i, :, self.sorted_indices[i, j]]
-                self.z[i, :, j] = _z[i, :, self.sorted_indices[i, j]]
+        self.x = np.take_along_axis(_x, self.sorted_indices, axis=2)
+        self.y = np.take_along_axis(_y, self.sorted_indices, axis=2)
+        self.z = np.take_along_axis(_z, self.sorted_indices, axis=2)
 
     def finalize(self):
-        n_wind_directions = np.shape(self.x)[0]
-        n_turbines = np.shape(self.x)[2]
-
         # Replace the turbines in their unsorted order so that
         # we can report values in a sane way.
-        _x = np.zeros_like(self.x)
-        _y = np.zeros_like(self.y)
-        _z = np.zeros_like(self.z)
-        for i in range(n_wind_directions):
-            for j in range(n_turbines):
-                _x[i, :, j] = self.x[i, :, self.unsorted_indices[i, j]]
-                _y[i, :, j] = self.y[i, :, self.unsorted_indices[i, j]]
-                _z[i, :, j] = self.z[i, :, self.unsorted_indices[i, j]]
-        self.x = _x
-        self.y = _y
-        self.z = _z
+        self.x = np.take_along_axis(self.x, self.unsorted_indices, axis=2)
+        self.y = np.take_along_axis(self.y, self.unsorted_indices, axis=2)
+        self.z = np.take_along_axis(self.z, self.unsorted_indices, axis=2)
 
 
 # class FlowFieldGrid(Grid):

--- a/src/solver.py
+++ b/src/solver.py
@@ -14,11 +14,7 @@ jimenez_deflection_model = JimenezVelocityDeflection()
 jensen_deficit_model = JensenVelocityDeficit()
 
 
-def sequential_solver(farm: Farm, flow_field: FlowField) -> None:
-
-    grid = TurbineGrid(farm.coordinates, flow_field.reference_turbine_diameter, flow_field.reference_wind_height, 5)
-    grid.expand_atmospheric_conditions(flow_field.n_wind_directions, flow_field.n_wind_speeds)
-    flow_field.initialize_velocity_field(grid)
+def sequential_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid) -> None:
 
     # <<interface>>
     jimenez_args = jimenez_deflection_model.prepare_function(grid, farm.rotor_diameter[:, :, [0]], farm.farm_controller.yaw_angles)

--- a/src/solver.py
+++ b/src/solver.py
@@ -28,10 +28,10 @@ def sequential_solver(farm: Farm, flow_field: FlowField) -> None:
     velocity_deficit = np.zeros_like(flow_field.u_initial)
 
     # Calculate the velocity deficit sequentially from upstream to downstream turbines
-    for i in range(grid.n_turbines - 1):
+    for i in range(grid.n_turbines):
 
         u = flow_field.u_initial - velocity_deficit
-        u[:, :, i + 1 :, :, :] = 0  # TODO: explain
+        u[:, :, i+1:, :, :] = 0  # TODO: explain
 
         thrust_coefficient = Ct(
             velocities=u,

--- a/src/turbine.py
+++ b/src/turbine.py
@@ -12,10 +12,9 @@
 
 # See https://floris.readthedocs.io for documentation
 
-from typing import Dict, List, Union
-from collections.abc import Iterable
 import math
 from typing import Any, Dict, List, Union
+from collections.abc import Iterable
 
 import attr
 import numpy as np
@@ -32,14 +31,14 @@ from src.base_class import BaseClass
 
 
 def _filter_convert(ix_filter: Union[np.ndarray, None], sample_arg: np.ndarray) -> Union[np.ndarray, None]:
-    """This function selects turbine indeces from the given array of turbine properties
+    """This function selects turbine indices from the given array of turbine properties
     over the simulation's atmospheric conditions (wind directions / wind speeds).
     It converts the ix_filter to a standard format of `np.ndarray`s for filtering
     certain arguments.
 
     Args:
         ix_filter (Union[np.ndarray, None]): The indices, or truth array-like object to
-            use for filtering. None implies that all indeces in the sample_arg
+            use for filtering. None implies that all indices in the sample_arg
             should be selected.
         sample_arg (np.ndarray): Any argument that will be filtered, to be used for
             creating the shape. This should be of shape:
@@ -54,7 +53,7 @@ def _filter_convert(ix_filter: Union[np.ndarray, None], sample_arg: np.ndarray) 
     # there's nothing we can do with it.
     if not isinstance(ix_filter, Iterable) and ix_filter is not None:
         raise TypeError("Expected ix_filter to be an Iterable or None")
-    
+
     # Check that the sample_arg is a Numpy array. If it isn't, we
     # can't get its shape.
     if not isinstance(sample_arg, np.ndarray):
@@ -153,7 +152,7 @@ def Ct(
     yaw_angle: np.ndarray,  # (wind directions, wind speeds, turbines)
     fCt: np.ndarray,  # (wind directions, wind speeds, turbines)
     ix_filter: np.ndarray = None,
-) -> np.ndarray:  # (wind directions, wind speeds, turbines)   
+) -> np.ndarray:  # (wind directions, wind speeds, turbines)
     """Thrust coefficient of a turbine incorporating the yaw angle.
     The value is interpolated from the coefficient of thrust vs
     wind speed table using the rotor swept area average velocity.
@@ -274,6 +273,7 @@ class PowerThrustTable(FromDictMixin):
         ValueError: Raised if the power, thrust, and wind_speed are not all 1-d array-like shapes.
         ValueError: Raised if power, thrust, and wind_speed don't have the same number of values.
     """
+
     # TODO: How to handle duplicate entries for a single wind speed?
     # This affects the interpolation in fCt / fCp
     power: List[float] = attr.ib(converter=attrs_array_converter)
@@ -394,10 +394,7 @@ class Turbine(BaseClass):
         """
         return 0.5 * self.rotor_area * self.fCp(velocities) * self.generator_efficiency * velocities ** 3
 
-
-    def fCp(
-        self, sample_wind_speeds: Union[float, np.ndarray]
-    ) -> Union[float, np.ndarray]:
+    def fCp(self, sample_wind_speeds: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
         """Calculates the coefficient of power at a given wind speed.
 
         Returns:
@@ -420,7 +417,6 @@ class Turbine(BaseClass):
             return _cp[0]
         return _cp
 
-
     def fCt(self, at_wind_speed: np.ndarray) -> np.ndarray:
         """
         Given an array of wind speeds, this function
@@ -438,11 +434,9 @@ class Turbine(BaseClass):
         """
         return self.fCt_interp(at_wind_speed)
 
-
     @rotor_diameter.validator
     def reset_rotor_diameter_dependencies(self, instance: str, value: float) -> None:
-        """Resets the `rotor_radius` and `rotor_area` attributes.
-        """
+        """Resets the `rotor_radius` and `rotor_area` attributes."""
         # Temporarily turn off validators to avoid infinite recursion
         attr.set_run_validators(False)
 

--- a/src/wake_deflection/jimenez.py
+++ b/src/wake_deflection/jimenez.py
@@ -62,9 +62,9 @@ class JimenezVelocityDeflection(BaseClass):
     def function(
         self,
         i: int,
-        Ct: np.ndarray,  # (n wind speeds, n turbines)
+        Ct: np.ndarray,
         *,
-        x: np.ndarray,  # (n_wind_speeds, n turbines, n grid, n grid)
+        x: np.ndarray,
         reference_rotor_diameter: float,
         yaw_angle: np.ndarray,  # (n wind speeds, n turbines)
     ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,37 @@ def print_test_values(average_velocities: list, thrusts: list, powers: list, axi
         )
 
 
+
+WIND_DIRECTIONS = [  # , 293.0, 315.0],
+    270.0,
+    270.0,
+]
+N_WIND_DIRECTIONS = len(WIND_DIRECTIONS)
+WIND_SPEEDS = [
+    8.0,
+    9.0,
+    10.0,
+    11.0,
+]
+N_WIND_SPEEDS = len(WIND_SPEEDS)
+N_TURBINES = 3
+X_COORDS = [
+    0.0,
+    5 * 126.0,
+    10 * 126.0
+]
+Y_COORDS = [
+    0.0,
+    0.0,
+    0.0
+]
+Z_COORDS = [
+    90.0,
+    90.0,
+    90.0
+]
+GRID_RESOLUTION = 2
+
 @pytest.fixture
 def sample_inputs_fixture():
     return SampleInputs()
@@ -225,8 +256,8 @@ class SampleInputs:
         }
 
         self.farm = {
-            "wind_speeds": [8.0, 9.0, 10.0],
-            "wind_directions": [270.0, 270.0],  # , 293.0, 315.0],
+            "wind_speeds": WIND_SPEEDS,
+            "wind_directions": WIND_DIRECTIONS,
             "turbulence_intensity": [0.1],
             "wind_shear": 0.12,
             "wind_veer": 0.0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,9 @@ def print_test_values(average_velocities: list, thrusts: list, powers: list, axi
 
 WIND_DIRECTIONS = [  # , 293.0, 315.0],
     270.0,
-    270.0,
+    360.0,
+    293.0,
+    315.0,
 ]
 N_WIND_DIRECTIONS = len(WIND_DIRECTIONS)
 WIND_SPEEDS = [

--- a/tests/flow_field_unit_test.py
+++ b/tests/flow_field_unit_test.py
@@ -18,7 +18,8 @@ import pytest
 
 from src import FlowField
 
-from .grid_unit_test import N_TURBINES, turbine_grid_fixture
+from tests.grid_unit_test import turbine_grid_fixture
+from tests.conftest import N_TURBINES
 
 
 @pytest.fixture
@@ -37,9 +38,6 @@ def test_n_wind_directions(flow_field_fixture):
 
 def test_initialize_velocity_field(flow_field_fixture, turbine_grid_fixture):
     flow_field_fixture.wind_shear = 1.0
-    turbine_grid_fixture.expand_atmospheric_conditions(
-        flow_field_fixture.n_wind_directions, flow_field_fixture.n_wind_speeds
-    )
     flow_field_fixture.initialize_velocity_field(turbine_grid_fixture)
 
     # Check the shape of the velocity arrays: u_initial, v_initial, w_initial  and u, v, w

--- a/tests/grid_unit_test.py
+++ b/tests/grid_unit_test.py
@@ -17,25 +17,9 @@ import pytest
 import numpy as np
 from src import FlowFieldGrid, TurbineGrid
 from src.utilities import Vec3
-
-
-GRID_RESOLUTION = 2
-N_TURBINES = 3
-X_COORDS = [
-    0.0,
-    5 * 126.0,
-    10 * 126.0
-]
-Y_COORDS = [
-    0.0,
-    0.0,
-    0.0
-]
-Z_COORDS = [
-    90.0,
-    90.0,
-    90.0
-]
+from tests.conftest import X_COORDS, Y_COORDS, Z_COORDS, N_TURBINES
+from tests.conftest import GRID_RESOLUTION
+from tests.conftest import WIND_DIRECTIONS, WIND_SPEEDS, N_WIND_DIRECTIONS, N_WIND_SPEEDS
 
 # TODO: test the dimension expansion
 
@@ -44,10 +28,11 @@ def turbine_grid_fixture(sample_inputs_fixture) -> TurbineGrid:
     turbine_coordinates = list(zip(X_COORDS, Y_COORDS, Z_COORDS))
     turbine_coordinates = [Vec3(c) for c in turbine_coordinates]
     return TurbineGrid(
-        turbine_coordinates,
-        sample_inputs_fixture.turbine["rotor_diameter"],
-        sample_inputs_fixture.farm["reference_wind_height"],
-        GRID_RESOLUTION
+        turbine_coordinates=turbine_coordinates,
+        reference_turbine_diameter=sample_inputs_fixture.turbine["rotor_diameter"],
+        wind_directions=np.array(WIND_DIRECTIONS),
+        wind_speeds=np.array(WIND_SPEEDS),
+        grid_resolution=GRID_RESOLUTION
     )
 
 
@@ -72,32 +57,32 @@ def test_turbine_set_grid(turbine_grid_fixture):
     # then, search for any elements that are true and negate the results
     # if an element is zero, the not will return true
     # if an element is non-zero, the not will return false
-    assert not np.any( turbine_grid_fixture.x - expected_x_grid )
-    assert not np.any( turbine_grid_fixture.y - expected_y_grid )
-    assert not np.any( turbine_grid_fixture.z - expected_z_grid )
+    assert not np.any( turbine_grid_fixture.x[0,0] - expected_x_grid )
+    assert not np.any( turbine_grid_fixture.y[0,0] - expected_y_grid )
+    assert not np.any( turbine_grid_fixture.z[0,0] - expected_z_grid )
 
 
 def test_turbinegrid_dimensions(turbine_grid_fixture):
-    assert np.shape(turbine_grid_fixture.x) == (N_TURBINES, GRID_RESOLUTION, GRID_RESOLUTION)
-    assert np.shape(turbine_grid_fixture.y) == (N_TURBINES, GRID_RESOLUTION, GRID_RESOLUTION)
-    assert np.shape(turbine_grid_fixture.z) == (N_TURBINES, GRID_RESOLUTION, GRID_RESOLUTION)
+    assert np.shape(turbine_grid_fixture.x) == (N_WIND_DIRECTIONS, N_WIND_SPEEDS, N_TURBINES, GRID_RESOLUTION, GRID_RESOLUTION)
+    assert np.shape(turbine_grid_fixture.y) == (N_WIND_DIRECTIONS, N_WIND_SPEEDS, N_TURBINES, GRID_RESOLUTION, GRID_RESOLUTION)
+    assert np.shape(turbine_grid_fixture.z) == (N_WIND_DIRECTIONS, N_WIND_SPEEDS, N_TURBINES, GRID_RESOLUTION, GRID_RESOLUTION)
 
 
-def test_flow_field_set_bounds(flow_field_grid_fixture):
-    assert flow_field_grid_fixture.xmin == -252.0
-    assert flow_field_grid_fixture.xmax == 2520.0
-    assert flow_field_grid_fixture.ymin == -252.0
-    assert flow_field_grid_fixture.ymax == 252.0
-    assert flow_field_grid_fixture.zmin == 0.1
-    assert flow_field_grid_fixture.zmax == 540
+# def test_flow_field_set_bounds(flow_field_grid_fixture):
+#     assert flow_field_grid_fixture.xmin == -252.0
+#     assert flow_field_grid_fixture.xmax == 2520.0
+#     assert flow_field_grid_fixture.ymin == -252.0
+#     assert flow_field_grid_fixture.ymax == 252.0
+#     assert flow_field_grid_fixture.zmin == 0.1
+#     assert flow_field_grid_fixture.zmax == 540
 
 
-def test_flow_field_set_grid(flow_field_grid_fixture):
-    assert [flow_field_grid_fixture.x[0][0][0], flow_field_grid_fixture.y[0][0][0], flow_field_grid_fixture.z[0][0][0]] == [ -252.0, -252.0, 0.1]
-    assert [flow_field_grid_fixture.x[1][0][0], flow_field_grid_fixture.y[0][0][0], flow_field_grid_fixture.z[0][0][0]] == [ 2520.0, -252.0, 0.1]
-    assert [flow_field_grid_fixture.x[0][0][0], flow_field_grid_fixture.y[0][1][0], flow_field_grid_fixture.z[0][0][0]] == [ -252.0,  252.0, 0.1]
-    assert [flow_field_grid_fixture.x[1][0][0], flow_field_grid_fixture.y[0][1][0], flow_field_grid_fixture.z[0][0][0]] == [ 2520.0,  252.0, 0.1]
-    assert [flow_field_grid_fixture.x[0][0][0], flow_field_grid_fixture.y[0][0][0], flow_field_grid_fixture.z[0][0][1]] == [ -252.0, -252.0, 540.0]
-    assert [flow_field_grid_fixture.x[1][0][0], flow_field_grid_fixture.y[0][0][0], flow_field_grid_fixture.z[0][0][1]] == [ 2520.0, -252.0, 540.0]
-    assert [flow_field_grid_fixture.x[0][0][0], flow_field_grid_fixture.y[0][1][0], flow_field_grid_fixture.z[0][0][1]] == [ -252.0,  252.0, 540.0]
-    assert [flow_field_grid_fixture.x[1][0][0], flow_field_grid_fixture.y[0][1][0], flow_field_grid_fixture.z[0][0][1]] == [ 2520.0,  252.0, 540.0]
+# def test_flow_field_set_grid(flow_field_grid_fixture):
+#     assert [flow_field_grid_fixture.x[0][0][0], flow_field_grid_fixture.y[0][0][0], flow_field_grid_fixture.z[0][0][0]] == [ -252.0, -252.0, 0.1]
+#     assert [flow_field_grid_fixture.x[1][0][0], flow_field_grid_fixture.y[0][0][0], flow_field_grid_fixture.z[0][0][0]] == [ 2520.0, -252.0, 0.1]
+#     assert [flow_field_grid_fixture.x[0][0][0], flow_field_grid_fixture.y[0][1][0], flow_field_grid_fixture.z[0][0][0]] == [ -252.0,  252.0, 0.1]
+#     assert [flow_field_grid_fixture.x[1][0][0], flow_field_grid_fixture.y[0][1][0], flow_field_grid_fixture.z[0][0][0]] == [ 2520.0,  252.0, 0.1]
+#     assert [flow_field_grid_fixture.x[0][0][0], flow_field_grid_fixture.y[0][0][0], flow_field_grid_fixture.z[0][0][1]] == [ -252.0, -252.0, 540.0]
+#     assert [flow_field_grid_fixture.x[1][0][0], flow_field_grid_fixture.y[0][0][0], flow_field_grid_fixture.z[0][0][1]] == [ 2520.0, -252.0, 540.0]
+#     assert [flow_field_grid_fixture.x[0][0][0], flow_field_grid_fixture.y[0][1][0], flow_field_grid_fixture.z[0][0][1]] == [ -252.0,  252.0, 540.0]
+#     assert [flow_field_grid_fixture.x[1][0][0], flow_field_grid_fixture.y[0][1][0], flow_field_grid_fixture.z[0][0][1]] == [ 2520.0,  252.0, 540.0]

--- a/tests/grid_unit_test.py
+++ b/tests/grid_unit_test.py
@@ -15,7 +15,7 @@
 
 import pytest
 import numpy as np
-from src import FlowFieldGrid, TurbineGrid
+from src import TurbineGrid #, FlowFieldGrid
 from src.utilities import Vec3
 from tests.conftest import X_COORDS, Y_COORDS, Z_COORDS, N_TURBINES
 from tests.conftest import GRID_RESOLUTION
@@ -36,16 +36,16 @@ def turbine_grid_fixture(sample_inputs_fixture) -> TurbineGrid:
     )
 
 
-@pytest.fixture
-def flow_field_grid_fixture(sample_inputs_fixture):
-    turbine_coordinates = list(zip(X_COORDS, Y_COORDS, Z_COORDS))
-    turbine_coordinates = [Vec3(c) for c in turbine_coordinates]
-    return FlowFieldGrid(
-        turbine_coordinates,
-        sample_inputs_fixture.turbine["rotor_diameter"],
-        sample_inputs_fixture.farm["reference_wind_height"],
-        Vec3([2,2,2])
-    )
+# @pytest.fixture
+# def flow_field_grid_fixture(sample_inputs_fixture):
+#     turbine_coordinates = list(zip(X_COORDS, Y_COORDS, Z_COORDS))
+#     turbine_coordinates = [Vec3(c) for c in turbine_coordinates]
+#     return FlowFieldGrid(
+#         turbine_coordinates,
+#         sample_inputs_fixture.turbine["rotor_diameter"],
+#         sample_inputs_fixture.farm["reference_wind_height"],
+#         Vec3([2,2,2])
+#     )
 
 
 def test_turbine_set_grid(turbine_grid_fixture):

--- a/tests/grid_unit_test.py
+++ b/tests/grid_unit_test.py
@@ -53,16 +53,8 @@ def turbine_grid_fixture(sample_inputs_fixture) -> TurbineGrid:
 
 @pytest.fixture
 def flow_field_grid_fixture(sample_inputs_fixture):
-    n_turbines = len(sample_inputs_fixture.farm["layout_x"])
-    turbine_coordinates = []
-    for i in range(n_turbines):
-        turbine_coordinates.append(
-            Vec3([
-                sample_inputs_fixture.farm["layout_x"][i],
-                sample_inputs_fixture.farm["layout_y"][i],
-                0.0
-            ])
-        )
+    turbine_coordinates = list(zip(X_COORDS, Y_COORDS, Z_COORDS))
+    turbine_coordinates = [Vec3(c) for c in turbine_coordinates]
     return FlowFieldGrid(
         turbine_coordinates,
         sample_inputs_fixture.turbine["rotor_diameter"],

--- a/tests/reg_tests/jensen_jimenez_regression_test.py
+++ b/tests/reg_tests/jensen_jimenez_regression_test.py
@@ -82,20 +82,15 @@ def test_regression_tandem(sample_inputs_fixture):
     sample_inputs_fixture.floris["wake"]["properties"]["deflection_model"] = DEFLECTION_MODEL
 
     floris = Floris(input_dict=sample_inputs_fixture.floris)
-
-    n_turbines = len(floris.farm.layout_x)
-    n_wind_speeds = floris.flow_field.n_wind_speeds  # TODO: change to 1 when wind direction is added
-
     floris.go()
 
     n_turbines = len(floris.farm.layout_x)
+    n_wind_speeds = floris.flow_field.n_wind_speeds
+    n_wind_directions = floris.flow_field.n_wind_directions
 
     velocities = floris.flow_field.u[:, :, :, :, :]
-    n_wind_directions = np.shape(velocities)[0]
-    n_wind_speeds = np.shape(velocities)[1]
-
-    test_results = np.zeros((n_wind_directions, n_wind_speeds, n_turbines, 4))
     yaw_angles = floris.farm.farm_controller.yaw_angles
+    test_results = np.zeros((n_wind_directions, n_wind_speeds, n_turbines, 4))
 
     farm_avg_velocities = average_velocity(
         velocities,
@@ -189,24 +184,16 @@ def test_regression_yaw(sample_inputs_fixture):
     sample_inputs_fixture.floris["wake"]["properties"]["deflection_model"] = DEFLECTION_MODEL
 
     floris = Floris(input_dict=sample_inputs_fixture.floris)
-
-    n_turbines = len(floris.farm.layout_x)
-    n_wind_speeds = floris.flow_field.n_wind_speeds  # TODO: change to 1 when wind direction is added
-    # n_wind_directions = len(turbines)
-
-    # yaw the upstream turbine 5 degrees
-    floris.farm.farm_controller.set_yaw_angles(np.array([5.0, 0.0, 0.0]))  # TODO: n_wind_directions
-
+    floris.farm.farm_controller.set_yaw_angles(np.array([5.0, 0.0, 0.0]))
     floris.go()
 
     n_turbines = len(floris.farm.layout_x)
+    n_wind_speeds = floris.flow_field.n_wind_speeds
+    n_wind_directions = floris.flow_field.n_wind_directions
 
     velocities = floris.flow_field.u[:, :, :, :, :]
-    n_wind_directions = np.shape(velocities)[0]
-    n_wind_speeds = np.shape(velocities)[1]
-
-    test_results = np.zeros((n_wind_directions, n_wind_speeds, n_turbines, 4))
     yaw_angles = floris.farm.farm_controller.yaw_angles
+    test_results = np.zeros((n_wind_directions, n_wind_speeds, n_turbines, 4))
 
     farm_avg_velocities = average_velocity(
         velocities,

--- a/tests/reg_tests/jensen_jimenez_regression_test.py
+++ b/tests/reg_tests/jensen_jimenez_regression_test.py
@@ -130,7 +130,7 @@ def test_regression_tandem(sample_inputs_fixture):
             farm_axial_inductions,
         )
 
-    assert_results_arrays(test_results[0], baseline)
+    assert_results_arrays(test_results[0,0:3], baseline)
 
 def test_regression_rotation(sample_inputs_fixture):
     """
@@ -268,4 +268,4 @@ def test_regression_yaw(sample_inputs_fixture):
             farm_axial_inductions,
         )
 
-    assert_results_arrays(test_results[0], yawed_baseline)
+    assert_results_arrays(test_results[0,0:3], yawed_baseline)

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -28,10 +28,8 @@ from src.turbine import (
     average_velocity,
 )
 from tests.conftest import SampleInputs
+from tests.conftest import WIND_SPEEDS
 
-
-WIND_DIRECTIONS = [270.0, 293.0, 315.0]  # TODO: 0, -N, 360, 460
-WIND_SPEEDS = [8.0, 9.0, 10.0, 11.0]
 
 # size 3 x 4 x 1 x 1
 WIND_SPEEDS_BROADCAST = np.stack(

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -27,8 +27,7 @@ from src.turbine import (
     axial_induction,
     average_velocity,
 )
-from tests.conftest import SampleInputs
-from tests.conftest import WIND_SPEEDS
+from tests.conftest import WIND_SPEEDS, SampleInputs
 
 
 # size 3 x 4 x 1 x 1
@@ -142,7 +141,7 @@ def test_filter_convert():
     # When the sample_arg is not a Numpy array, the function
     # should return None
     ix_filter = None
-    sample_arg = [1,2,3]
+    sample_arg = [1, 2, 3]
     with pytest.raises(TypeError):
         _filter_convert(ix_filter, sample_arg)
 
@@ -164,7 +163,7 @@ def test_filter_convert():
 
     # Test that a 1-D boolean truth array is returned
     # When the index filter is None and the sample_arg
-    # is a Numpy array of values, the returned filter indeces
+    # is a Numpy array of values, the returned filter indices
     # should be all True and have the shape of the turbine-dimension
     ix_filter = None
     sample_arg = np.arange(N).reshape(1, 1, N)


### PR DESCRIPTION
**Feature or improvement description**
This pull request completes the wind farm sort and rotation functionality. It's mostly handled in the Grid class where the turbine-dimension of the x,y,z arrays are sorted on initialization. Then, the wake model proceeds as usual. Finally, the turbines are put back in their unsorted position within the various data arrays (grid x,y,z and flow field u,v,w). This "finalize" procedure should be improved.