### PR TITLE
Fix Formatting and Test Bugs

### DIFF
--- a/examples/example_input.json
+++ b/examples/example_input.json
@@ -1,19 +1,5 @@
 {
-  "name": "example_floris_input_file",
   "description": "Single turbine with Jensen / Jimenez wake models",
-  "floris_version": "v3.0.0",
-
-  "logging": {
-    "console": {
-      "enable": true,
-      "level": "INFO"
-    },
-    "file": {
-      "enable": false,
-      "level": "INFO"
-    }
-  },
-
   "farm": {
     "layout_x": [
       0.0
@@ -28,7 +14,7 @@
       "WTG-1"
     ]
   },
-
+  "floris_version": "v3.0.0",
   "flow_field": {
     "air_density": 1.225,
     "reference_turbine_diameter": 126.0,
@@ -45,11 +31,23 @@
     ],
     "wind_veer": 0.0
   },
-
+  "logging": {
+    "console": {
+      "enable": true,
+      "level": "INFO"
+    },
+    "file": {
+      "enable": false,
+      "level": "INFO"
+    }
+  },
+  "name": "example_floris_input_file",
   "turbine": {
     "nrel_5mw": {
       "generator_efficiency": 1.0,
       "hub_height": 90.0,
+      "pP": 1.88,
+      "pT": 1.88,
       "power_thrust_table": {
         "power": [
           0.0,
@@ -202,12 +200,9 @@
           25.5
         ]
       },
-      "pP": 1.88,
-      "pT": 1.88,
       "rotor_diameter": 126.0
     }
   },
-
   "wake": {
     "model_strings": {
       "combination_model": null,
@@ -215,22 +210,20 @@
       "turbulence_model": null,
       "velocity_model": "gauss"
     },
-    "parameters": {
-      "wake_deflection_parameters": {
-        "gauss": {
-          "dm": 1.0,
-          "eps_gain": 0.2,
-          "use_secondary_steering": true
-        }
-      },
-      "wake_velocity_parameters": {
-        "gauss": {
-          "calculate_VW_velocities": true,
-          "eps_gain": 0.2,
-          "ka": 0.38,
-          "kb": 0.004,
-          "use_yaw_added_recovery": true
-        }
+    "wake_deflection_parameters": {
+      "gauss": {
+        "dm": 1.0,
+        "eps_gain": 0.2,
+        "use_secondary_steering": true
+      }
+    },
+    "wake_velocity_parameters": {
+      "gauss": {
+        "calculate_VW_velocities": true,
+        "eps_gain": 0.2,
+        "ka": 0.38,
+        "kb": 0.004,
+        "use_yaw_added_recovery": true
       }
     }
   }

--- a/examples/example_input.json
+++ b/examples/example_input.json
@@ -1,5 +1,19 @@
 {
+  "name": "example_floris_input_file",
   "description": "Single turbine with Jensen / Jimenez wake models",
+  "floris_version": "v3.0.0",
+
+  "logging": {
+    "console": {
+      "enable": true,
+      "level": "INFO"
+    },
+    "file": {
+      "enable": false,
+      "level": "INFO"
+    }
+  },
+
   "farm": {
     "layout_x": [
       0.0
@@ -14,7 +28,7 @@
       "WTG-1"
     ]
   },
-  "floris_version": "v3.0.0",
+
   "flow_field": {
     "air_density": 1.225,
     "reference_turbine_diameter": 126.0,
@@ -31,17 +45,7 @@
     ],
     "wind_veer": 0.0
   },
-  "logging": {
-    "console": {
-      "enable": true,
-      "level": "INFO"
-    },
-    "file": {
-      "enable": false,
-      "level": "INFO"
-    }
-  },
-  "name": "example_floris_input_file",
+
   "turbine": {
     "nrel_5mw": {
       "generator_efficiency": 1.0,
@@ -203,6 +207,7 @@
       "rotor_diameter": 126.0
     }
   },
+
   "wake": {
     "model_strings": {
       "combination_model": null,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+python_files = tests/*.py
+filterwarnings =
+    ignore::DeprecationWarning:pandas.*:

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -20,20 +20,20 @@ from floris.simulation import BaseClass, BaseModel
 
 
 @attr.s(auto_attribs=True)
-class TestClass(BaseClass):
+class ClassTest(BaseClass):
     x: int = attr.ib(default=1, converter=int)
     model_string: str = attr.ib(default="test", converter=str)
 
 
 def test_get_model_defaults():
-    defaults = TestClass.get_model_defaults()
+    defaults = ClassTest.get_model_defaults()
     assert len(defaults) == 2
     assert defaults["x"] == 1
     assert defaults["model_string"] == "test"
 
 
 def test_get_model_values():
-    cls = TestClass(x=4, model_string="new")
+    cls = ClassTest(x=4, model_string="new")
     values = cls._get_model_dict()
     assert len(values) == 2
     assert values["x"] == 4

--- a/tests/profiling.py
+++ b/tests/profiling.py
@@ -26,7 +26,7 @@ if len(sys.argv) > 1:
     floris = Floris(sys.argv[1])
 else:
     floris = Floris.from_json("examples/example_input.json")
-floris.farm.flow_field.calculate_wake()
+floris.steady_state_atmospheric_condition()
 
 start = time.time()
 
@@ -36,6 +36,6 @@ def run_floris():
     return floris
 
 
-cProfile.run('re.compile("floris.farm.flow_field.calculate_wake()")')
+cProfile.run('re.compile("floris.steady_state_atmospheric_condition()")')
 end = time.time()
 print(start, end, end - start)

--- a/tests/profiling.py
+++ b/tests/profiling.py
@@ -22,20 +22,21 @@ from copy import deepcopy
 from floris.simulation import Floris
 
 
-if len(sys.argv) > 1:
-    floris = Floris(sys.argv[1])
-else:
-    floris = Floris.from_json("examples/example_input.json")
+# Provide a path to an input file
+# floris = Floris.from_json(sys.argv[1])
+
+# Or use a default. If using default, this script must be called from the root dir
+# i.e. cd floris/ && python tests/profiling.py
+floris = Floris.from_json("examples/example_input.json")
+
 floris.steady_state_atmospheric_condition()
-
-start = time.time()
-
 
 def run_floris():
     floris = Floris.from_json("examples/example_input.json")
     return floris
 
-
+start = time.time()
 cProfile.run('re.compile("floris.steady_state_atmospheric_condition()")')
 end = time.time()
+
 print(start, end, end - start)

--- a/tests/utilities_unit_test.py
+++ b/tests/utilities_unit_test.py
@@ -35,7 +35,7 @@ from floris.utilities import (
 
 
 @attr.s(auto_attribs=True)
-class TestClass(FromDictMixin):
+class ClassTest(FromDictMixin):
     x: int = attr.ib(default=1)
     y: float = float_attrib(default=2.1)
     z: List[str] = attr.ib(default=["empty"], validator=iter_validator(list, str))
@@ -43,7 +43,7 @@ class TestClass(FromDictMixin):
 
 
 @attr.s(auto_attribs=True)
-class TestClassArray(FromDictMixin):
+class ArrayTestClass(FromDictMixin):
     arr: np.ndarray = attr.ib(  # type: ignore
         default=[1, 2], converter=attrs_array_converter, on_setattr=attr.setters.convert  # type: ignore
     )
@@ -92,14 +92,14 @@ def test_wrap_360():
 
 def test_FromDictMixin_defaults():
     inputs = {}
-    cls = TestClass.from_dict(inputs)
-    assert cls == TestClass()
+    cls = ClassTest.from_dict(inputs)
+    assert cls == ClassTest()
 
 
 def test_FromDictMixin_custom():
     # Test custom inputs
     inputs = dict(x=3, y=3.2, z=["one", "two"], arr=[3, 4, 5.5])
-    cls = TestClass.from_dict(inputs)
+    cls = ClassTest.from_dict(inputs)
     assert inputs["x"] == cls.x
     assert inputs["y"] == cls.y
     assert inputs["z"] == cls.z
@@ -108,21 +108,21 @@ def test_FromDictMixin_custom():
 
 def test_is_default():
     with pytest.raises(ValueError):
-        TestClass(model="real deal")
+        ClassTest(model="real deal")
 
 
 def test_iter_validator():
     # Check wrong member type
     with pytest.raises(TypeError):
-        TestClass(z=[4.3, 1])
+        ClassTest(z=[4.3, 1])
 
     # Check mixed member types
     with pytest.raises(TypeError):
-        TestClass(z=[4.3, "1"])
+        ClassTest(z=[4.3, "1"])
 
     # Check wrong iterable type
     with pytest.raises(TypeError):
-        TestClass(z=("a", "b"))
+        ClassTest(z=("a", "b"))
 
 
 def test_attrs_array_converter():
@@ -130,29 +130,29 @@ def test_attrs_array_converter():
     test_arr = np.array(test_list)
 
     # Test conversion on initialization
-    cls = TestClassArray(arr=test_list)
+    cls = ArrayTestClass(arr=test_list)
     np.testing.assert_array_equal(test_arr, cls.arr)
 
     # Test converstion on reset
-    cls = TestClassArray()
+    cls = ArrayTestClass()
     cls.arr = test_list
     np.testing.assert_array_equal(test_arr, cls.arr)
 
 
 def test_model_attrib():
     with pytest.raises(ValueError):
-        TestClass(model="real deal")
+        ClassTest(model="real deal")
 
-    cls = TestClass()
+    cls = ClassTest()
     with pytest.raises(attr.exceptions.FrozenAttributeError):
         cls.model = "real deal"
 
 
 def test_float_attrib():
     with pytest.raises(ValueError):
-        TestClass(y="fail")
+        ClassTest(y="fail")
 
-    cls = TestClass(y=1)
+    cls = ClassTest(y=1)
     assert cls.y == 1.0
 
     cls.y = "1"


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
This PR silences the pandas warning when running in a way that maintains floris-caused warnings, and fixes the couple of bugs in the testing suite. Specifically, the test classes have been renamed to not violate the pytest naming convention with a a leading `Test`, and the `tests/profiling.py` and `examples/example_input.json` have been brought fully up to spec with the current state of the code base. Ironically, this had nothing to do with attrs at the end of the day!

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->
Closes #14 

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
- tests/
- examples/

**Additional supporting information**
<!-- Add any other context about the problem here. -->
The method to silence the pandas warning regarding the usage of `np.bool` was silenced in the same manner that I've implemented in OpenOA and validated to ensure we still keep our own errors/out of date code warnings.

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->
Tests all pass, just with the few divide by zero warnings that have always been there.

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
