### PR TITLE
Change default farm size in optimize_yaw.py to 25

### DIFF
--- a/examples/optimization/yaw_optimization/optimize_yaw.py
+++ b/examples/optimization/yaw_optimization/optimize_yaw.py
@@ -34,7 +34,7 @@ def load_floris():
     )
 
     # Specify wind farm layout and update in the floris object
-    N = 9  # number of turbines per row and per column
+    N = 5  # number of turbines per row and per column
     X, Y = np.meshgrid(
         5.0 * fi.floris.grid.reference_turbine_diameter * np.arange(0, N, 1),
         5.0 * fi.floris.grid.reference_turbine_diameter * np.arange(0, N, 1),


### PR DESCRIPTION
This allows users to run the example in 2 minutes with reasonable results. The previous value of N=9 yielded an 81 turbine farm, which takes in the order of an hour. This is too high for an example case.