### PR TITLE
Redesign/feature/layout symmetry optimization

### DIFF
--- a/examples/optimization/yaw_optimization/optimize_yaw.py
+++ b/examples/optimization/yaw_optimization/optimize_yaw.py
@@ -34,7 +34,7 @@ def load_floris():
     )
 
     # Specify wind farm layout and update in the floris object
-    N = 9  # number of turbines per row and per column
+    N = 5  # number of turbines per row and per column
     X, Y = np.meshgrid(
         5.0 * fi.floris.grid.reference_turbine_diameter * np.arange(0, N, 1),
         5.0 * fi.floris.grid.reference_turbine_diameter * np.arange(0, N, 1),
@@ -122,8 +122,8 @@ if __name__ == "__main__":
         minimum_yaw_angle=0.0,  # Allowable yaw angles lower bound
         maximum_yaw_angle=20.0,  # Allowable yaw angles upper bound
         Ny_passes=[5, 4],
-        reduce_ngrid=False,
         exclude_downstream_turbines=True,
+        exploit_layout_symmetry=True,
     )
 
     df_opt = yaw_opt._optimize()

--- a/examples/optimization/yaw_optimization/yaw_optimization_benchmarking.py
+++ b/examples/optimization/yaw_optimization/yaw_optimization_benchmarking.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
             maximum_yaw_angle=20.0,  # Allowable yaw angles upper bound
             yaw_angles_baseline=np.zeros((72, 1, len(fi.layout_x))),
             Ny_passes=[5, 4],
-            reduce_ngrid=False,
+            exploit_layout_symmetry=True,
             exclude_downstream_turbines=True,
         )
         df_opt = yaw_opt._optimize()

--- a/src/floris/tools/optimization/yaw_optimization/yaw_optimization_base.py
+++ b/src/floris/tools/optimization/yaw_optimization/yaw_optimization_base.py
@@ -17,7 +17,14 @@ import copy
 
 import numpy as np
 
-from .yaw_optimization_tools import derive_downstream_turbines  #, cluster_turbines
+
+from ....utilities import wrap_360
+
+from .yaw_optimization_tools import (
+    derive_downstream_turbines,
+    find_layout_symmetry,
+    #, cluster_turbines
+)
 
 
 class YawOptimization:
@@ -35,8 +42,10 @@ class YawOptimization:
         yaw_angles_baseline=None,
         x0=None,
         turbine_weights=None,
+        normalize_control_variables=False,
         calc_baseline_power=True,
         exclude_downstream_turbines=True,
+        exploit_layout_symmetry=True,
         # cluster_turbines=False,
         # cluster_wake_slope=0.30,
         # verify_convergence=True,
@@ -137,71 +146,137 @@ class YawOptimization:
             )
 
         # Initialize optimizer
-        self.reinitialize_opt(
-            minimum_yaw_angle=minimum_yaw_angle,
-            maximum_yaw_angle=maximum_yaw_angle,
-            yaw_angles_baseline=yaw_angles_baseline,
-            x0=x0,
-            turbine_weights=turbine_weights,
-            calc_baseline_power=calc_baseline_power,
-            exclude_downstream_turbines=exclude_downstream_turbines,
-            # cluster_turbines=cluster_turbines,
-            # cluster_wake_slope=cluster_wake_slope,
-            # verify_convergence=verify_convergence,
-            class_initialization=True,
-        )
+
+        # if cluster_turbines is not None:
+        #     self.cluster_turbines = cluster_turbines
+        # if cluster_wake_slope is not None:
+        #     self.cluster_wake_slope = cluster_wake_slope
+
+        # if verify_convergence is not None:
+        #     self.verify_convergence = verify_convergence
+
+        if yaw_angles_baseline is not None:
+            yaw_angles_baseline = self._unpack_variable(yaw_angles_baseline)
+            self.yaw_angles_baseline = yaw_angles_baseline
+        else:
+            b = self.fi.floris.farm.yaw_angles
+            self.yaw_angles_baseline = self._unpack_variable(b)
+            if np.any(np.abs(b) > 0.0):
+                print(
+                    "INFO: Baseline yaw angles were not specified and were derived from the floris object."
+                )
+                print(
+                    "INFO: The inherent yaw angles in the floris object are not all 0.0 degrees."
+                )
+
+        # Set optimization bounds
+        self.minimum_yaw_angle = self._unpack_variable(minimum_yaw_angle)
+        self.maximum_yaw_angle = self._unpack_variable(maximum_yaw_angle)
+
+        # Set initial condition for optimization
+        if x0 is not None:
+            self.x0 = self._unpack_variable(x0)
+        else:
+            self.x0 = self._unpack_variable(0.0)
+            for ti in range(self.nturbs):
+                yaw_lb = self.minimum_yaw_angle[:, 0, ti]
+                yaw_ub = self.maximum_yaw_angle[:, 0, ti]
+                idx = (yaw_lb > 0.0) | (yaw_ub < 0.0)
+                self.x0[idx, 0, ti] = (yaw_lb[idx] + yaw_ub[idx]) / 2.0
+
+        # Check inputs for consistency
+        if np.any(self.yaw_angles_baseline < self.minimum_yaw_angle):
+            print("INFO: yaw_angles_baseline exceed lower bound constraints.")
+        if np.any(self.yaw_angles_baseline > self.maximum_yaw_angle):
+            print("INFO: yaw_angles_baseline exceed upper bound constraints.")
+        if np.any(self.x0 < self.minimum_yaw_angle):
+            raise ValueError("Initial guess x0 exceeds lower bound constraints.")
+        if np.any(self.x0 > self.maximum_yaw_angle):
+            raise ValueError("Initial guess x0 exceeds upper bound constraints.")
+
+        # Define turbine weighing terms
+        if turbine_weights is None:
+            self.turbine_weights = self._unpack_variable(1.0)
+        else:
+            self.turbine_weights = self._unpack_variable(turbine_weights)
+
+        # Save remaining user options to self
+        self.normalize_variables = normalize_control_variables
+        self.calc_baseline_power = calc_baseline_power
+        self.exclude_downstream_turbines = exclude_downstream_turbines
+        self.exploit_layout_symmetry = exploit_layout_symmetry
+
+        # Prepare for optimization and calculate baseline powers (if applic.)
+        self._initialize()
+        self._calculate_baseline_farm_power()
 
     # Private methods
 
-    def _unpack_variable(self, variable):
+    def _initialize(self):
+        # Derive layout symmetry, if applicable
+        self._derive_layout_symmetry()
+
+        # Reduce optimization problem as much as possible
+        self._reduce_control_problem()
+
+        # Normalize optimization variables
+        if self.normalize_variables:
+            self._normalize_control_problem()
+
+    def _unpack_variable(self, variable, subset=False):
         """Take a variable, can be either a float, a list equal in
         length to the number of turbines, or an ndarray. It then
         upsamples this value so that it always matches the dimensions
         (self.nconds, self.nturbs).
         """
+        # Deal with full vs. subset dimensions
+        nturbs = self.nturbs
+        nconds = self.nconds
+        if subset:
+            nturbs = np.shape(self._x0_subset.shape[2])
+            nconds = self._nconds_subset
+
         # Then process maximum yaw angle
         if isinstance(variable, float):
             # If single value, copy over to all turbines
-            variable = np.tile(variable, (self.nturbs))
+            variable = np.tile(variable, (nturbs))
 
         variable = np.array(variable, dtype=float)
         if len(np.shape(variable)) == 1:
             # If one-dimensional array, copy over to all atmos. conditions
-            variable = np.tile(variable, (self.nconds, 1, 1))
+            variable = np.tile(variable, (nconds, 1, 1))
 
         if len(np.shape(variable)) == 2:
             raise UserWarning("This is an unrecognized shape.")
 
         return variable
-        
-    def _set_opt_bounds(self, minimum_yaw_angle, maximum_yaw_angle):
-        """
-        Set bounds for each turbine and each atmospheric condition based on
-        the user-specified minimum and maximum yaw angles.
 
-        Args:
-            minimum_yaw_angle ([float, list or ndarray]): Minimum turbine yaw
-            angle(s) in degrees.
-            maximum_yaw_angle ([float, list or ndarray]): Maximum turbine yaw
-            angle(s) in degrees.
-        """
-        # Save to self
-        self.minimum_yaw_angle = self._unpack_variable(minimum_yaw_angle)
-        self.maximum_yaw_angle = self._unpack_variable(maximum_yaw_angle)
-
-    def _reduce_control_variables(self):
+    def _reduce_control_problem(self):
         """
         This function reduces the control problem by eliminating turbines
         of which the yaw angles need not be optimized, either because of a
         user-specified set of bounds (where bounds[i][0] == bounds[i][1]),
         or alternatively turbines that are far downstream in the wind farm
-        and of which the wake does not impinge other turbines, if the
-        boolean exclude_downstream_turbines == True. The normalized initial
-        conditions and bounds are then calculated for the subset of turbines,
-        to be used in the optimization.
+        and of which the wake does not impinge other turbines, if
+        exclude_downstream_turbines == True. This function also reduces
+        the optimization problem by exploiting layout symmetry, if
+        exploit_layout_symmetry == True.
         """
+        # Initialize which turbines to optimize for
         self.turbs_to_opt = (self.maximum_yaw_angle - self.minimum_yaw_angle >= 0.001)
 
+        # Initialize subset variables as full set
+        self.fi_subset = copy.deepcopy(self.fi)
+        nconds_subset = copy.deepcopy(self.nconds)
+        minimum_yaw_angle_subset = copy.deepcopy(self.minimum_yaw_angle)
+        maximum_yaw_angle_subset = copy.deepcopy(self.maximum_yaw_angle)
+        x0_subset = copy.deepcopy(self.x0)
+        turbs_to_opt_subset = copy.deepcopy(self.turbs_to_opt)
+        turbine_weights_subset = copy.deepcopy(self.turbine_weights)
+        yaw_angles_template_subset = self._unpack_variable(0.0)
+        yaw_angles_baseline_subset = copy.deepcopy(self.yaw_angles_baseline)
+
+        # Define which turbines to optimize for
         if self.exclude_downstream_turbines:
             for iw, wd in enumerate(self.fi.floris.flow_field.wind_directions):
                 # Remove turbines from turbs_to_opt that are downstream
@@ -209,15 +284,32 @@ class YawOptimization:
                 downstream_turbines = np.array(downstream_turbines, dtype=int)
                 self.turbs_to_opt[iw, 0, downstream_turbines] = False
 
+        # Reduce optimization problem through layout symmetry
+        if (self.exploit_layout_symmetry) & (self._sym_df is not None):
+            # Reinitialize floris with subset of wind directions
+            wd_array = self.fi.floris.flow_field.wind_directions
+            wind_direction_subset = wd_array[self._sym_mapping_reduce]
+            self.fi_subset.reinitialize(wind_directions=wind_direction_subset)
+
+            # Reduce control variables
+            red_map = self._sym_mapping_reduce
+            nconds_subset = len(wind_direction_subset)
+            minimum_yaw_angle_subset = minimum_yaw_angle_subset[red_map, :, :]
+            maximum_yaw_angle_subset = maximum_yaw_angle_subset[red_map, :, :]
+            x0_subset = x0_subset[red_map, :, :]
+            turbs_to_opt_subset = turbs_to_opt_subset[red_map, :, :]
+            turbine_weights_subset = turbine_weights_subset[red_map, :, :]
+            yaw_angles_template_subset = yaw_angles_template_subset[red_map, :, :]
+            yaw_angles_baseline_subset = yaw_angles_baseline_subset[red_map, :, :]
+
         # Set up a template yaw angles array with default solutions. The default
         # solutions are either 0.0 or the allowable yaw angle closest to 0.0 deg.
         # This solution addresses both downstream turbines, minimizing their abs.
         # yaw offset, and additionally fixing equality-constrained turbines to
         # their appropriate yaw angle.
-        yaw_angles_template = self._unpack_variable(0.0)
         for ti in range(self.nturbs):
-            yaw_lb = self.minimum_yaw_angle[:, 0, ti]
-            yaw_ub = self.maximum_yaw_angle[:, 0, ti]
+            yaw_lb = minimum_yaw_angle_subset[:, 0, ti]
+            yaw_ub = maximum_yaw_angle_subset[:, 0, ti]
 
             # Find bound that is closest to zero
             bounds = np.vstack([yaw_lb, yaw_ub]).T
@@ -226,36 +318,30 @@ class YawOptimization:
 
             # Overwrite all values that are not allowed to be 0.0 with bound value closest to zero
             idx = (yaw_lb > 0.0) | (yaw_ub < 0.0)
-            yaw_angles_template[idx, 0, ti] = yaw_mb[idx]
-        self.yaw_angles_template = yaw_angles_template
+            yaw_angles_template_subset[idx, 0, ti] = yaw_mb[idx]
 
-        # # Derive reduced initial conditions
-        # self.x0_subset = [[] for _ in range(self.nconds)]
-        # for ii, x0 in enumerate(self.x0):
-        #     self.x0_subset[ii] = x0[self.turbs_to_opt[ii, :]]
+        # Save all subset variables to self
+        self._nconds_subset = nconds_subset
+        self._minimum_yaw_angle_subset = minimum_yaw_angle_subset
+        self._maximum_yaw_angle_subset = maximum_yaw_angle_subset
+        self._x0_subset = x0_subset
+        self._turbs_to_opt_subset = turbs_to_opt_subset
+        self._turbine_weights_subset = turbine_weights_subset
+        self._yaw_angles_template_subset = yaw_angles_template_subset
+        self._yaw_angles_baseline_subset = yaw_angles_baseline_subset
 
-        # # Derive reduced minimum yaw angles (lower bounds)
-        # self.minimum_yaw_angle_subset = [[] for _ in range(self.nconds)]
-        # for ii, min_yaw in enumerate(self.minimum_yaw_angle):
-        #     self.minimum_yaw_angle_subset[ii] = min_yaw[self.turbs_to_opt[ii, :]]
-
-        # # Derive reduced maximum yaw angles (upper bounds)
-        # self.maximum_yaw_angle_subset = [[] for _ in range(self.nconds)]
-        # for ii, max_yaw in enumerate(self.maximum_yaw_angle):
-        #     self.maximum_yaw_angle_subset[ii] = max_yaw[self.turbs_to_opt[ii, :]]
-
-    def _normalize_control_variables(self):
+    def _normalize_control_problem(self):
         """
         This private function normalizes variables for the optimization
         problem, specifically the initial condition x0 and the bounds.
         Normalization can improve optimization performance when using common
         optimization methods such as the SciPy Optimization Toolbox.
         """
-        lb = np.min(self.minimum_yaw_angle)
-        ub = np.max(self.maximum_yaw_angle)
-        self.x0_norm = [self._norm(x0, lb, ub) for x0 in self.x0_subset]
-        self.minimum_yaw_angle_norm = [self._norm(y, lb, ub) for y in self.minimum_yaw_angle_subset]
-        self.maximum_yaw_angle_norm = [self._norm(y, lb, ub) for y in self.maximum_yaw_angle_subset]
+        lb = np.min(self._minimum_yaw_angle_subset)
+        ub = np.max(self._maximum_yaw_angle_subset)
+        self._x0_subset_norm = [self._norm(x0, lb, ub) for x0 in self._x0_subset]
+        self._minimum_yaw_angle_subset_norm = [self._norm(y, lb, ub) for y in self._minimum_yaw_angle_subset]
+        self._maximum_yaw_angle_subset_norm = [self._norm(y, lb, ub) for y in self._maximum_yaw_angle_subset]
 
     def _calculate_farm_power(self, yaw_angles=None, wd_array=None, turbine_weights=None):
         """
@@ -270,22 +356,25 @@ class YawOptimization:
             farm_power (float): Weighted wind farm power.
         """
         # Unpack all variables, whichever are defined.
-        fi = copy.deepcopy(self.fi)
+        fi_subset = copy.deepcopy(self.fi_subset)
         if wd_array is None:
-            wd_array = self.fi.floris.flow_field.wind_directions
+            wd_array = fi_subset.floris.flow_field.wind_directions
         if yaw_angles is None:
-            yaw_angles = self.yaw_angles_baseline
+            yaw_angles = self._yaw_angles_baseline_subset
         if turbine_weights is None:
-            turbine_weights = self.turbine_weights
+            turbine_weights = self._turbine_weights_subset
 
-        # Ensure format
-        yaw_angles = self._unpack_variable(yaw_angles)
+        # Ensure format [incompatible with _subset notation]
+        yaw_angles = self._unpack_variable(yaw_angles, subset=True)
+
+        # Correct wind direction definition: 270 deg is from left, cw positive
+        wd_array = wrap_360(270.0 + wd_array)
 
         # Calculate solutions
-        turbine_power = np.zeros((len(wd_array), self.nturbs))
-        fi.reinitialize(wind_directions=wd_array)
-        fi.calculate_wake(yaw_angles=yaw_angles)
-        turbine_power = fi.get_turbine_powers()
+        turbine_power = np.zeros_like(self._minimum_yaw_angle_subset[:, 0, :])
+        fi_subset.reinitialize(wind_directions=wd_array)
+        fi_subset.calculate_wake(yaw_angles=yaw_angles)
+        turbine_power = fi_subset.get_turbine_powers()
 
         # Multiply with turbine weighing terms
         turbine_power_weighted = np.multiply(turbine_weights, turbine_power)
@@ -298,9 +387,114 @@ class YawOptimization:
         angles.
         """
         if self.calc_baseline_power:
-            self.farm_power_baseline = self._calculate_farm_power(
-                self.yaw_angles_baseline
-            )
+            P = self._calculate_farm_power(self._yaw_angles_baseline_subset)
+            self._farm_power_baseline_subset = P
+            self.farm_power_baseline = self._unreduce_variable(P)
+
+    def _derive_layout_symmetry(self):
+        """Derive symmetry lines in the wind farm layout and use that
+        to reduce the optimization problem by 50 %.
+        """
+        self._sym_df = None  # Default option
+        if self.exploit_layout_symmetry:
+            # Check symmetry of bounds & turbine_weights
+            if np.unique(self.minimum_yaw_angle, axis=0).shape[0] > 1:
+                print("minimum_yaw_angle is not equal over wind directions.")
+                print("Exploiting of symmetry has been disabled.")
+                return
+
+            if np.unique(self.maximum_yaw_angle, axis=0).shape[0] > 1:
+                print("maximum_yaw_angle is not equal over wind directions.")
+                print("Exploiting of symmetry has been disabled.")
+                return
+
+            if np.unique(self.maximum_yaw_angle, axis=0).shape[0] > 1:
+                print("maximum_yaw_angle is not equal over wind directions.")
+                print("Exploiting of symmetry has been disabled.")
+                return
+
+            if np.unique(self.turbine_weights, axis=0).shape[0] > 1:
+                print("turbine_weights is not equal over wind directions.")
+                print("Exploiting of symmetry has been disabled.")
+                return
+
+            # Check if turbine_weights are consistently 1.0 everywhere
+            if np.any(np.abs(self.turbine_weights - 1.0) > 0.001):
+                print("turbine_weights are not uniformly 1.0.")
+                print("Exploiting of symmetry has been disabled.")
+                return
+
+            x = self.fi.layout_x
+            y = self.fi.layout_y
+            df = find_layout_symmetry(x=x, y=y)
+
+            # If no axes of symmetry, exit function
+            if df.shape[0] <= 0:
+                print("Wind farm layout in floris is not symmetrical.")
+                print("Exploitation of symmetry has been disabled.")
+                return
+
+            wd_array = self.fi.floris.flow_field.wind_directions
+            sym_step = df.iloc[0]["wd_range"][1]
+            if ((not 0.0 in wd_array) or(not sym_step in wd_array)):
+                print("Floris wind direction array does not " +
+                      "intersect {:.1f} and {:.1f}.".format(0.0, sym_step))
+                print("Exploitation of symmetry has been disabled.")
+                return
+
+            ids_minimal = (wd_array >= 0.0) & (wd_array < sym_step)
+            wd_array_min = wd_array[ids_minimal]
+            wd_array_remn = np.remainder(wd_array, sym_step)
+
+            if not np.all([(x in wd_array_min) for x in wd_array_remn]):
+                print("Wind direction array appears irregular.")
+                print("Exploitation of symmetry has been disabled.")
+
+            self._sym_mapping_extrap = np.array(
+                [np.where(np.abs(x - wd_array_min) < 0.0001)[0][0] 
+                for x in wd_array_remn], dtype=int)
+            
+            self._sym_mapping_reduce = copy.deepcopy(ids_minimal)
+            self._sym_df = df
+
+            return
+
+    def _unreduce_variable(self, variable):
+        # Check if needed to un-reduce at all, if not, return directly
+        if not self.exploit_layout_symmetry:
+            return variable
+    
+        if self._sym_df is None:
+            return variable
+
+        # Apply operation on right dimension
+        ndims = len(np.shape(variable))
+        if ndims == 1:
+            full_array = variable[self._sym_mapping_extrap]
+        elif ndims == 2:
+            full_array = variable[self._sym_mapping_extrap, :]
+        elif ndims == 3:
+            # First upsample to full wind rose
+            full_array = variable[self._sym_mapping_extrap, :, :]
+
+            # Now process turbine mapping
+            wd_array = self.fi.floris.flow_field.wind_directions
+            for ii, dfrow in self._sym_df.iloc[1::].iterrows():
+                ids = (
+                    (wd_array >= dfrow["wd_range"][0]) &
+                    (wd_array < dfrow["wd_range"][1])
+                )
+                tmap = np.argsort(dfrow["turbine_mapping"])
+                full_array[ids, :, :] = full_array[ids, :, :][:, :, tmap]
+        else:
+            raise UserWarning("Unknown data shape.")
+
+        return full_array
+
+    def _finalize(self):
+        # Finalization step for optimization: undo reduction step
+        self.farm_power_opt = self._unreduce_variable(self._farm_power_opt_subset)
+        self.yaw_angles_opt = self._unreduce_variable(self._yaw_angles_opt_subset)
 
     # def _cluster_turbines(self):
     #     """
@@ -329,214 +523,6 @@ class YawOptimization:
     #         )
 
     # Public methods
-
-    def reinitialize_opt(
-        self,
-        minimum_yaw_angle=None,
-        maximum_yaw_angle=None,
-        yaw_angles_baseline=None,
-        x0=None,
-        turbine_weights=None,
-        calc_baseline_power=True,
-        exclude_downstream_turbines=None,
-        # cluster_turbines=None,
-        # cluster_wake_slope=None,
-        # verify_convergence=None,
-        class_initialization=False,
-    ):
-        """
-        This method reinitializes any optimization parameters that are
-        specified. Otherwise, the current parameter values are kept.
-
-        Args:
-            minimum_yaw_angle (float, optional): Minimum constraint on yaw
-                angle (deg). This value will be ignored if bnds is also
-                specified. Defaults to None.
-            maximum_yaw_angle (float, optional): Maximum constraint on yaw
-                angle (deg). This value will be ignored if bnds is also
-                specified. Defaults to None.
-            yaw_angles_baseline (iterable, optional): The baseline yaw
-                angles used to calculate the initial and baseline power
-                production in the wind farm and used to normalize the cost
-                function. If none are specified, this variable is set equal
-                to the current yaw angles in floris. Note that this variable
-                need not meet the yaw constraints specified in self.bnds,
-                yet a warning is raised if it does to inform the user.
-                Defaults to None.
-            x0 (iterable, optional): The initial guess for the optimization
-                problem. These values must meet the constraints specified
-                in self.bnds. Note that, if exclude_downstream_turbines=True,
-                the initial guess for any downstream turbines are ignored
-                since they are not part of the optimization. Instead, the yaw
-                angles for those turbines are 0.0 if that meets the lower and
-                upper bound, or otherwise as close to 0.0 as feasible. If no
-                values for x0 are specified, x0 is set to be equal to zeros
-                wherever feasible (w.r.t. the bounds), and equal to the
-                average of its lower and upper bound for all non-downstream
-                turbines otherwise. Defaults to None.
-            bnds (iterable, optional): Bounds for the yaw angles, as tuples of
-                min, max values for each turbine (deg). One can fix the yaw
-                angle of certain turbines to a predefined value by setting that
-                turbine's lower bound equal to its upper bound (i.e., an
-                equality constraint), as: bnds[ti] = (x, x), where x is the
-                fixed yaw angle assigned to the turbine. This works for both
-                zero and nonzero yaw angles. Moreover, if
-                exclude_downstream_turbines=True, the yaw angles for all
-                downstream turbines will be 0.0 or a feasible value closest to
-                0.0. If none are specified, the bounds are set to
-                (minimum_yaw_angle, maximum_yaw_angle) for each turbine. Note
-                that, if bnds is not none, its values overwrite any value given
-                in minimum_yaw_angle and maximum_yaw_angle. Defaults to None.
-            opt_method (str, optional): The optimization method used by
-                scipy.optimize.minize. Defaults to None.
-            opt_options (dictionary, optional): Optimization options used by
-                scipy.optimize.minize. Defaults to None.
-            turbine_weights (iterable, optional): weighing terms that allow
-                the user to emphasize power gains at particular turbines or
-                completely ignore power gains from other turbines. The array
-                of turbine powers from floris is multiplied with this array
-                in the calculation of the objective function. If None, this
-                is an array with all values 1.0 and length equal to the
-                number of turbines. Defaults to None.
-            calc_init_power (bool, optional): If True, calculates initial
-                wind farm power for each set of wind conditions. Defaults to
-                None.
-            exclude_downstream_turbines (bool, optional): If True,
-                automatically finds and excludes turbines that are most
-                downstream from the optimization problem. This significantly
-                reduces computation time at no loss in performance. The yaw
-                angles of these downstream turbines are fixed to 0.0 deg if
-                the yaw bounds specified in self.bnds allow that, or otherwise
-                are fixed to the lower or upper yaw bound, whichever is closer
-                to 0.0. Defaults to None.
-            cluster_turbines (bool, optional): if True, clusters the wind
-                turbines into sectors and optimizes the cost function for each
-                farm sector separately. This can significantly reduce the
-                computational cost involved if the farm can indeed be separated
-                into multiple clusters. Defaults to None.
-            cluster_wake_slope (float, optional): linear slope of the wake
-                in the simplified linear expansion wake model (dy/dx). This
-                model is used to derive wake interactions between turbines and
-                to identify the turbine clusters. A good value is about equal
-                to the turbulence intensity in FLORIS. Though, since yaw
-                optimizations may shift the wake laterally, a safer option
-                is twice the turbulence intensity. Defaults to None.
-            verify_convergence (bool, optional): specifies whether the found
-                optimal yaw angles will be checked for accurately convergence.
-                With large farms, especially when using SciPy or other global
-                optimization methods, solutions do not always converge and
-                turbines that should have a 0.0 deg actually have a 1.0 deg
-                angle, for example. By enabling this function, the final yaw
-                angles are compared to their baseline values one-by-one for
-                the turbines to make sure no such convergence issues arise.
-                Defaults to None.
-        """
-        # Define number of atmospheric conditions
-        N = self.nconds
-        if self.fi.floris.flow_field.n_wind_speeds > 1:
-            raise NotImplementedError(
-                "Optimizer currently does not support more than one wind" +
-                " speed. Please assign FLORIS a single wind speed."
-            )
-
-        # if cluster_turbines is not None:
-        #     self.cluster_turbines = cluster_turbines
-        # if cluster_wake_slope is not None:
-        #     self.cluster_wake_slope = cluster_wake_slope
-
-        # if verify_convergence is not None:
-        #     self.verify_convergence = verify_convergence
-
-        if yaw_angles_baseline is not None:
-            yaw_angles_baseline = self._unpack_variable(yaw_angles_baseline)
-            self.yaw_angles_baseline = yaw_angles_baseline
-        else:
-            b = self.fi.floris.farm.yaw_angles
-            self.yaw_angles_baseline = self._unpack_variable(b)
-            if np.any(np.abs(b) > 0.0):
-                print(
-                    "INFO: Baseline yaw angles were not specified and were derived from the floris object."
-                )
-                print(
-                    "INFO: The inherent yaw angles in the floris object are not all 0.0 degrees."
-                )
-
-        # Set optimization bounds
-        if minimum_yaw_angle is not None:
-            self.minimum_yaw_angle = minimum_yaw_angle
-        if maximum_yaw_angle is not None:
-            self.maximum_yaw_angle = maximum_yaw_angle
-        self._set_opt_bounds(self.minimum_yaw_angle, self.maximum_yaw_angle)
-
-        # Set initial condition for optimization
-        if x0 is not None:
-            self.x0 = self._unpack_variable(x0)
-        else:
-            if class_initialization:
-                self.x0 = self._unpack_variable(0.0)
-                for ti in range(self.nturbs):
-                    yaw_lb = self.minimum_yaw_angle[:, 0, ti]
-                    yaw_ub = self.maximum_yaw_angle[:, 0, ti]
-                    idx = (yaw_lb > 0.0) | (yaw_ub < 0.0)
-                    self.x0[idx, 0, ti] = (yaw_lb[idx] + yaw_ub[idx]) / 2.0
-
-        if np.any(self.yaw_angles_baseline < self.minimum_yaw_angle):
-            print("INFO: yaw_angles_baseline exceed lower bound constraints.")
-        if np.any(self.yaw_angles_baseline > self.maximum_yaw_angle):
-            print("INFO: yaw_angles_baseline exceed upper bound constraints.")
-        if np.any(self.x0 < self.minimum_yaw_angle):
-            raise ValueError("Initial guess x0 exceeds lower bound constraints.")
-        if np.any(self.x0 > self.maximum_yaw_angle):
-            raise ValueError("Initial guess x0 exceeds upper bound constraints.")
-
-        if turbine_weights is None:
-            self.turbine_weights = self._unpack_variable(1.0)
-        else:
-            self.turbine_weights = self._unpack_variable(turbine_weights)
-
-        if calc_baseline_power is not None:
-            self.calc_baseline_power = calc_baseline_power
-
-        if exclude_downstream_turbines is not None:
-            self.exclude_downstream_turbines = exclude_downstream_turbines
-
-        self._calculate_baseline_farm_power()
-        # self._cluster_turbines()
-
-    def reinitialize_flow_field(
-        self,
-        wind_layout=None,
-        wind_shear=None,
-        wind_veer=None,
-        specified_wind_height=None,
-        turbulence_intensity=None,
-        turbulence_kinetic_energy=None,
-        air_density=None,
-        wake=None,
-        layout_array=None,
-        with_resolution=None,
-    ):
-        """
-        Mapper function to the function in the floris model with the same
-        function name `reinitialize_flow_field`. This function additionally
-        recalculates the baseline power production and reperforms clustering
-        of the wind farm. Namely, either or both can change under different
-        atmospheric conditions.
-        """
-        self.fi.reinitialize_flow_field(
-            wind_layout=wind_layout,
-            wind_shear=wind_shear,
-            wind_veer=wind_veer,
-            specified_wind_height=specified_wind_height,
-            turbulence_intensity=turbulence_intensity,
-            turbulence_kinetic_energy=turbulence_kinetic_energy,
-            air_density=air_density,
-            wake=wake,
-            layout_array=layout_array,
-            with_resolution=with_resolution,
-        )
-        self._calculate_baseline_farm_power()
-        # self._cluster_turbines()
 
     # def _verify_solution(
     #     self,

--- a/src/floris/tools/optimization/yaw_optimization/yaw_optimization_base.py
+++ b/src/floris/tools/optimization/yaw_optimization/yaw_optimization_base.py
@@ -367,8 +367,8 @@ class YawOptimization:
         # Ensure format [incompatible with _subset notation]
         yaw_angles = self._unpack_variable(yaw_angles, subset=True)
 
-        # Correct wind direction definition: 270 deg is from left, cw positive
-        wd_array = wrap_360(270.0 + wd_array)
+        # # Correct wind direction definition: 270 deg is from left, cw positive
+        # wd_array = wrap_360(wd_array)
 
         # Calculate solutions
         turbine_power = np.zeros_like(self._minimum_yaw_angle_subset[:, 0, :])

--- a/src/floris/tools/optimization/yaw_optimization/yaw_optimization_tools.py
+++ b/src/floris/tools/optimization/yaw_optimization/yaw_optimization_tools.py
@@ -317,7 +317,7 @@ def derive_downstream_turbines(fi, wind_direction, wake_slope=0.30, plot_lines=F
     return turbs_downstream
 
 
-def find_layout_symmetry(x, y, step_sizes = [15.0, 1.0], eps=0.00001):
+def find_layout_symmetry(x, y, step_sizes = [15.0], eps=0.00001):
     # Place center of farm at (0, 0)
     x = x - np.mean(x)
     y = y - np.mean(y)

--- a/src/floris/tools/optimization/yaw_optimization/yaw_optimization_tools.py
+++ b/src/floris/tools/optimization/yaw_optimization/yaw_optimization_tools.py
@@ -15,6 +15,7 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
+import pandas as pd
 
 
 def cluster_turbines(fi, wind_direction=None, wake_slope=0.30, plot_lines=False):
@@ -314,3 +315,63 @@ def derive_downstream_turbines(fi, wind_direction, wake_slope=0.30, plot_lines=F
         )
 
     return turbs_downstream
+
+
+def find_layout_symmetry(x, y, step_sizes = [15.0, 1.0], eps=0.00001):
+    # Place center of farm at (0, 0)
+    x = x - np.mean(x)
+    y = y - np.mean(y)
+    nturbs = len(x)
+
+    # Evaluate at continuously refined step size
+    for ss in step_sizes:
+        wd_array = np.arange(ss, 180.001, ss)
+        for wd in wd_array:
+            is_faulty = False
+            x_rot = (
+                np.cos(wd * np.pi / 180.0) * x
+                - np.sin(wd * np.pi / 180.0) * y
+            )
+            y_rot = (
+                np.sin(wd * np.pi / 180.0) * x
+                + np.cos(wd * np.pi / 180.0) * y
+            )
+
+            # compare differences: force turbine 0 to (0, 0)
+            for ti in range(nturbs):
+                if np.all(np.abs(x_rot[ti] - x) > eps):
+                    is_faulty = True
+                    break
+
+            if is_faulty:
+                continue
+
+            for ti in range(nturbs):
+                if np.all(np.abs(y_rot[ti] - y) > eps):
+                    is_faulty = True
+                    break
+
+            if is_faulty:
+                continue
+
+            # Found a valid solution. Now find mappings
+            wd_eval_array = [(0.0, wd)]
+            mapping_array = [list(range(nturbs))]
+            for wd_eval in np.arange(wd, 360.0, wd):
+                ang = wd_eval * -1.0  # Opposite rotation
+                x_rot = (
+                    np.cos(ang * np.pi / 180.0) * x
+                    - np.sin(ang * np.pi / 180.0) * y
+                )
+                y_rot = (
+                    np.sin(ang * np.pi / 180.0) * x
+                    + np.cos(ang * np.pi / 180.0) * y
+                )
+                wd_eval_array.append((wd_eval, wd_eval + wd))
+                id_mapping = [np.where((np.abs(xr - x) < eps) &(np.abs(yr - y) < eps))[0][0] for xr, yr in zip(x_rot, y_rot)]
+                mapping_array.append(id_mapping)
+
+            df = pd.DataFrame({"wd_range": wd_eval_array, "turbine_mapping": mapping_array})
+            return df
+    
+    return pd.DataFrame()  # Return empty dataframe if completes without finding solution


### PR DESCRIPTION
**Feature or improvement description**
This PR adds a feature that determines if there is a minimal rotation of the wind farm layout such that all turbine coordinates will coincide with the non-rotated turbine's coordinates. For rectangular wind farms, this will be a 90 deg rotation. For triangular wind farms, this is a 120 deg rotation, and for rectangular farms, this is 180 deg. Knowing this rotation, the optimization problem can be reduced to a subset of the initial wind directions (i.e., for rectangular farms, from 0 through 90 deg) and then extrapolated to the remaining wind directions.

**Related issue, if one exists**
None.

**Impacted areas of the software**
Yaw optimization.

**Additional supporting information**
This functionality adds very little overhead, so I am defaulting it to `True`. Additionally, I have rearranged some of the yaw optimization code to work with `_subset` variables. This can later also be used to deal with wind farm clustering or other simplifications without having to constantly overwrite the full variables.

**Test results, if applicable**
Here are the results for 3x3 square wind farm:
![image](https://user-images.githubusercontent.com/22119448/149966203-c4f9ba06-dade-4600-81e0-5225fc9fe0bf.png)

Wind farm power:
![image](https://user-images.githubusercontent.com/22119448/149966278-cdfd44c7-3e89-4601-97a8-5b7a6924c079.png)

Optimal yaw angles (first 4 turbines):
![image](https://user-images.githubusercontent.com/22119448/149966387-c3f9f3d4-60f2-4aa8-8b07-db56d10e32a2.png)

![image](https://user-images.githubusercontent.com/22119448/149966426-2328dfd8-79f7-440e-b9d2-e2e05acffe71.png)

![image](https://user-images.githubusercontent.com/22119448/149966483-f14ccb0b-f543-4cf3-8b43-0b955235fb36.png)

![image](https://user-images.githubusercontent.com/22119448/149966523-e2dfa590-636c-464b-b306-29db0182fce0.png)

![image](https://user-images.githubusercontent.com/22119448/149966605-559eba90-c40c-4eb8-b6e2-ecfc6a0a786a.png)

```
Time without symmetry: 5.9 s
Time with symmetry: 3.3 s

         wd_range              turbine_mapping
0     (0.0, 90.0)  [0, 1, 2, 3, 4, 5, 6, 7, 8]
1   (90.0, 180.0)  [6, 3, 0, 7, 4, 1, 8, 5, 2]
2  (180.0, 270.0)  [8, 7, 6, 5, 4, 3, 2, 1, 0]
3  (270.0, 360.0)  [2, 5, 8, 1, 4, 7, 0, 3, 6]
```

And the results with v2.4 are identical too:
![image](https://user-images.githubusercontent.com/22119448/149967100-6a06aced-2ec5-42a1-8b0d-87eba7c0ca12.png)

![image](https://user-images.githubusercontent.com/22119448/149967133-5babf7d3-0f1a-482d-9f97-70a464bbb16f.png)

Additional timings for the square benchmarking layouts, in comparison to the exact same optimization with `exploit_layout_symmetry=False`:
```
[N=25] Time without symmetry: 98.8 s
[N=25] Time with symmetry: 35.6 s (2.8x speedup)

[N=49] Time without symmetry: 661.2 s
[N=49] Time with symmetry: 195.4 s (3.4x speedup)

[N=81] Time without symmetry: 3056 s
[N=81] Time with symmetry: 848.9 s (3.6x speedup)
```

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
