### PR TITLE
Support 4 dimensional data arrays in Turbine, Farm, ..., classes

### DIFF
--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -311,8 +311,6 @@ class Farm(BaseClass):
 
     def expand_farm_properties(
         self,
-        # n_wind_directions: int,
-        # n_wind_speeds: int,
         n_findex: int,
         sorted_coord_indices
     ):

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -234,13 +234,13 @@ class Farm(BaseClass):
         # Sort yaw angles from most upstream to most downstream wind turbine
         self.yaw_angles_sorted = np.take_along_axis(
             self.yaw_angles,
-            sorted_indices[:, :, :, 0, 0],
-            axis=2,
+            sorted_indices[:, :, 0, 0],
+            axis=1,
         )
         self.tilt_angles_sorted = np.take_along_axis(
             self.tilt_angles,
-            sorted_indices[:, :, :, 0, 0],
-            axis=2,
+            sorted_indices[:, :, 0, 0],
+            axis=1,
         )
         self.state = State.INITIALIZED
 
@@ -311,16 +311,19 @@ class Farm(BaseClass):
 
     def expand_farm_properties(
         self,
-        n_wind_directions: int,
-        n_wind_speeds: int,
+        # n_wind_directions: int,
+        # n_wind_speeds: int,
+        n_findex: int,
         sorted_coord_indices
     ):
         template_shape = np.ones_like(sorted_coord_indices)
         self.hub_heights_sorted = np.take_along_axis(
             self.hub_heights * template_shape,
             sorted_coord_indices,
-            axis=2
+            axis=1 # PF: Pretty sure this needs to move to 1 but can confirm later
         )
+
+        # TODO: Waiting for RM and CB for this part~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         if 'multi_dimensional_cp_ct' in self.turbine_definitions[0].keys() \
             and self.turbine_definitions[0]['multi_dimensional_cp_ct'] is True:
             wd_dim = np.shape(template_shape)[0]
@@ -332,7 +335,7 @@ class Farm(BaseClass):
                         np.shape(template_shape)
                     ),
                     sorted_coord_indices,
-                    axis=2
+                    axis=2 #PF TODO: Probably this should change to 1
                 )
                 self.turbine_power_interps_sorted = np.take_along_axis(
                     np.reshape(
@@ -340,82 +343,87 @@ class Farm(BaseClass):
                         np.shape(template_shape)
                     ),
                     sorted_coord_indices,
-                    axis=2
+                    axis=2#PF TODO: Probably this should change to 1
                 )
             else:
                 self.turbine_fCts_sorted = np.take_along_axis(
                     np.reshape(self.turbine_fCts, np.shape(template_shape)),
                     sorted_coord_indices,
-                    axis=2
+                    axis=2#PF TODO: Probably this should change to 1
                 )
                 self.turbine_power_interps_sorted = np.take_along_axis(
                     np.reshape(self.turbine_power_interps, np.shape(template_shape)),
                     sorted_coord_indices,
-                    axis=2
+                    axis=2#PF TODO: Probably this should change to 1
                 )
+        # TODO: Waiting for RM and CB for this part~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
         self.rotor_diameters_sorted = np.take_along_axis(
             self.rotor_diameters * template_shape,
             sorted_coord_indices,
-            axis=2
+            axis=1
         )
         self.TSRs_sorted = np.take_along_axis(
             self.TSRs * template_shape,
             sorted_coord_indices,
-            axis=2
+            axis=1
         )
         self.ref_density_cp_cts_sorted = np.take_along_axis(
             self.ref_density_cp_cts * template_shape,
             sorted_coord_indices,
-            axis=2
+            axis=1
         )
         self.ref_tilt_cp_cts_sorted = np.take_along_axis(
             self.ref_tilt_cp_cts * template_shape,
             sorted_coord_indices,
-            axis=2
+            axis=1
         )
         self.correct_cp_ct_for_tilt_sorted = np.take_along_axis(
             self.correct_cp_ct_for_tilt * template_shape,
             sorted_coord_indices,
-            axis=2
+            axis=1
         )
         self.pPs_sorted = np.take_along_axis(
             self.pPs * template_shape,
             sorted_coord_indices,
-            axis=2
+            axis=1
         )
         self.pTs_sorted = np.take_along_axis(
             self.pTs * template_shape,
             sorted_coord_indices,
-            axis=2
+            axis=1
         )
 
         # NOTE: Tilt angles are sorted twice - here and in initialize()
         self.tilt_angles_sorted = np.take_along_axis(
             self.tilt_angles * template_shape,
             sorted_coord_indices,
-            axis=2
+            axis=1
         )
         self.turbine_type_map_sorted = np.take_along_axis(
             np.reshape(
-                [turb["turbine_type"] for turb in self.turbine_definitions] * n_wind_directions,
+                [turb["turbine_type"] for turb in self.turbine_definitions] * n_findex,
                 np.shape(sorted_coord_indices)
             ),
             sorted_coord_indices,
-            axis=2
+            axis=1
         )
 
-    def set_yaw_angles(self, n_wind_directions: int, n_wind_speeds: int):
-        # TODO Is this just for initializing yaw angles to zero?
-        self.yaw_angles = np.zeros((n_wind_directions, n_wind_speeds, self.n_turbines))
-        self.yaw_angles_sorted = np.zeros((n_wind_directions, n_wind_speeds, self.n_turbines))
+    def set_yaw_angles(self, n_findex: int):
 
-    def set_tilt_to_ref_tilt(self, n_wind_directions: int, n_wind_speeds: int):
+        # TODO Is this just for initializing yaw angles to zero?
+        # TODO (PF): I think just setting to 0
+
+        self.yaw_angles = np.zeros((n_findex, self.n_turbines))
+        self.yaw_angles_sorted = np.zeros((n_findex, self.n_turbines))
+
+    def set_tilt_to_ref_tilt(self, n_findex: int):
         self.tilt_angles = (
-            np.ones((n_wind_directions, n_wind_speeds, self.n_turbines))
+            np.ones((n_findex, self.n_turbines))
             * self.ref_tilt_cp_cts
         )
         self.tilt_angles_sorted = (
-            np.ones((n_wind_directions, n_wind_speeds, self.n_turbines))
+            np.ones((n_findex, self.n_turbines))
             * self.ref_tilt_cp_cts
         )
 
@@ -433,68 +441,68 @@ class Farm(BaseClass):
             and self.turbine_definitions[0]['multi_dimensional_cp_ct'] is True:
             self.turbine_fCts = np.take_along_axis(
                 self.turbine_fCts_sorted,
-                unsorted_indices[:,:,:,0,0],
-                axis=2
+                unsorted_indices[:,:,0,0],#TODO PF: Changed to 1, RM/CB confirm
+                axis=1 #TODO PF: Changed to 1, RM/CB confirm
             )
             self.turbine_power_interps = np.take_along_axis(
                 self.turbine_power_interps_sorted,
-                unsorted_indices[:,:,:,0,0],
-                axis=2
+                unsorted_indices[:,:,0,0],#TODO PF: Changed to 1, RM/CB confirm
+                axis=1#TODO PF: Changed to 1, RM/CB confirm
             )
         self.yaw_angles = np.take_along_axis(
             self.yaw_angles_sorted,
-            unsorted_indices[:,:,:,0,0],
-            axis=2
+            unsorted_indices[:,:,0,0],
+            axis=1
         )
         self.tilt_angles = np.take_along_axis(
             self.tilt_angles_sorted,
-            unsorted_indices[:,:,:,0,0],
-            axis=2
+            unsorted_indices[:,:,0,0],
+            axis=1
         )
         self.hub_heights = np.take_along_axis(
             self.hub_heights_sorted,
-            unsorted_indices[:,:,:,0,0],
-            axis=2
+            unsorted_indices[:,:,0,0],
+            axis=1
         )
         self.rotor_diameters = np.take_along_axis(
             self.rotor_diameters_sorted,
-            unsorted_indices[:,:,:,0,0],
-            axis=2
+            unsorted_indices[:,:,0,0],
+            axis=1
         )
         self.TSRs = np.take_along_axis(
             self.TSRs_sorted,
-            unsorted_indices[:,:,:,0,0],
-            axis=2
+            unsorted_indices[:,:,0,0],
+            axis=1
         )
         self.ref_density_cp_cts = np.take_along_axis(
             self.ref_density_cp_cts_sorted,
-            unsorted_indices[:,:,:,0,0],
-            axis=2
+            unsorted_indices[:,:,0,0],
+            axis=1
         )
         self.ref_tilt_cp_cts = np.take_along_axis(
             self.ref_tilt_cp_cts_sorted,
-            unsorted_indices[:,:,:,0,0],
-            axis=2
+            unsorted_indices[:,:,0,0],
+            axis=1
         )
         self.correct_cp_ct_for_tilt = np.take_along_axis(
             self.correct_cp_ct_for_tilt_sorted,
-            unsorted_indices[:,:,:,0,0],
-            axis=2
+            unsorted_indices[:,:,0,0],
+            axis=1
         )
         self.pPs = np.take_along_axis(
             self.pPs_sorted,
-            unsorted_indices[:,:,:,0,0],
-            axis=2
+            unsorted_indices[:,:,0,0],
+            axis=1
         )
         self.pTs = np.take_along_axis(
             self.pTs_sorted,
-            unsorted_indices[:,:,:,0,0],
-            axis=2
+            unsorted_indices[:,:,0,0],
+            axis=1
         )
         self.turbine_type_map = np.take_along_axis(
             self.turbine_type_map_sorted,
-            unsorted_indices[:,:,:,0,0],
-            axis=2
+            unsorted_indices[:,:,0,0],
+            axis=1
         )
         self.state.USED
 

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -433,7 +433,7 @@ class Farm(BaseClass):
             and self.turbine_definitions[0]['multi_dimensional_cp_ct'] is True:
             self.turbine_fCts = np.take_along_axis(
                 self.turbine_fCts_sorted,
-                unsorted_indices[:,:,0,0]
+                unsorted_indices[:,:,0,0],
                 axis=1
             )
             self.turbine_power_interps = np.take_along_axis(

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -318,10 +318,10 @@ class Farm(BaseClass):
         self.hub_heights_sorted = np.take_along_axis(
             self.hub_heights * template_shape,
             sorted_coord_indices,
-            axis=1 # PF: Pretty sure this needs to move to 1 but can confirm later
+            axis=1
         )
 
-        # TODO: Waiting for RM and CB for this part~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # TODO: update multidimensional turbine for 4D arrays
         if 'multi_dimensional_cp_ct' in self.turbine_definitions[0].keys() \
             and self.turbine_definitions[0]['multi_dimensional_cp_ct'] is True:
             wd_dim = np.shape(template_shape)[0]
@@ -333,7 +333,7 @@ class Farm(BaseClass):
                         np.shape(template_shape)
                     ),
                     sorted_coord_indices,
-                    axis=2 #PF TODO: Probably this should change to 1
+                    axis=2 # TODO: This should probably be 1
                 )
                 self.turbine_power_interps_sorted = np.take_along_axis(
                     np.reshape(
@@ -341,21 +341,19 @@ class Farm(BaseClass):
                         np.shape(template_shape)
                     ),
                     sorted_coord_indices,
-                    axis=2#PF TODO: Probably this should change to 1
+                    axis=2 # TODO: This should probably be 1
                 )
             else:
                 self.turbine_fCts_sorted = np.take_along_axis(
                     np.reshape(self.turbine_fCts, np.shape(template_shape)),
                     sorted_coord_indices,
-                    axis=2#PF TODO: Probably this should change to 1
+                    axis=1
                 )
                 self.turbine_power_interps_sorted = np.take_along_axis(
                     np.reshape(self.turbine_power_interps, np.shape(template_shape)),
                     sorted_coord_indices,
-                    axis=2#PF TODO: Probably this should change to 1
+                    axis=1
                 )
-        # TODO: Waiting for RM and CB for this part~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
         self.rotor_diameters_sorted = np.take_along_axis(
             self.rotor_diameters * template_shape,
             sorted_coord_indices,
@@ -408,10 +406,6 @@ class Farm(BaseClass):
         )
 
     def set_yaw_angles(self, n_findex: int):
-
-        # TODO Is this just for initializing yaw angles to zero?
-        # TODO (PF): I think just setting to 0
-
         self.yaw_angles = np.zeros((n_findex, self.n_turbines))
         self.yaw_angles_sorted = np.zeros((n_findex, self.n_turbines))
 
@@ -439,13 +433,13 @@ class Farm(BaseClass):
             and self.turbine_definitions[0]['multi_dimensional_cp_ct'] is True:
             self.turbine_fCts = np.take_along_axis(
                 self.turbine_fCts_sorted,
-                unsorted_indices[:,:,0,0],#TODO PF: Changed to 1, RM/CB confirm
-                axis=1 #TODO PF: Changed to 1, RM/CB confirm
+                unsorted_indices[:,:,0,0]
+                axis=1
             )
             self.turbine_power_interps = np.take_along_axis(
                 self.turbine_power_interps_sorted,
-                unsorted_indices[:,:,0,0],#TODO PF: Changed to 1, RM/CB confirm
-                axis=1#TODO PF: Changed to 1, RM/CB confirm
+                unsorted_indices[:,:,0,0],
+                axis=1
             )
         self.yaw_angles = np.take_along_axis(
             self.yaw_angles_sorted,

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -245,19 +245,19 @@ def Ct(
     wind speed table using the rotor swept area average velocity.
 
     Args:
-        velocities (NDArrayFloat[wd, ws, turbines, grid1, grid2]): The velocity field at
+        velocities (NDArrayFloat[sample, turbines, grid1, grid2]): The velocity field at
             a turbine.
-        yaw_angle (NDArrayFloat[wd, ws, turbines]): The yaw angle for each turbine.
-        tilt_angle (NDArrayFloat[wd, ws, turbines]): The tilt angle for each turbine.
-        ref_tilt_cp_ct (NDArrayFloat[wd, ws, turbines]): The reference tilt angle for each turbine
+        yaw_angle (NDArrayFloat[sample, turbines]): The yaw angle for each turbine.
+        tilt_angle (NDArrayFloat[sample, turbines]): The tilt angle for each turbine.
+        ref_tilt_cp_ct (NDArrayFloat[sample, turbines]): The reference tilt angle for each turbine
             that the Cp/Ct tables are defined at.
         fCt (dict): The thrust coefficient interpolation functions for each turbine. Keys are
             the turbine type string and values are the interpolation functions.
         tilt_interp (Iterable[tuple]): The tilt interpolation functions for each
             turbine.
-        correct_cp_ct_for_tilt (NDArrayBool[wd, ws, turbines]): Boolean for determining if the
+        correct_cp_ct_for_tilt (NDArrayBool[sample, turbines]): Boolean for determining if the
             turbines Cp and Ct should be corrected for tilt.
-        turbine_type_map: (NDArrayObject[wd, ws, turbines]): The Turbine type definition
+        turbine_type_map: (NDArrayObject[sample, turbines]): The Turbine type definition
             for each turbine.
         ix_filter (NDArrayFilter | Iterable[int] | None, optional): The boolean array, or
             integer indices as an iterable of array to filter out before calculation.
@@ -275,12 +275,12 @@ def Ct(
 
     # Down-select inputs if ix_filter is given
     if ix_filter is not None:
-        velocities = velocities[:, :, ix_filter]
-        yaw_angle = yaw_angle[:, :, ix_filter]
-        tilt_angle = tilt_angle[:, :, ix_filter]
-        ref_tilt_cp_ct = ref_tilt_cp_ct[:, :, ix_filter]
-        turbine_type_map = turbine_type_map[:, :, ix_filter]
-        correct_cp_ct_for_tilt = correct_cp_ct_for_tilt[:, :, ix_filter]
+        velocities = velocities[:, ix_filter]
+        yaw_angle = yaw_angle[:, ix_filter]
+        tilt_angle = tilt_angle[:, ix_filter]
+        ref_tilt_cp_ct = ref_tilt_cp_ct[:, ix_filter]
+        turbine_type_map = turbine_type_map[:, ix_filter]
+        correct_cp_ct_for_tilt = correct_cp_ct_for_tilt[:, ix_filter]
 
     average_velocities = average_velocity(
         velocities,
@@ -445,7 +445,7 @@ def average_velocity(
     """
 
     # The input velocities are expected to be a 5 dimensional array with shape:
-    # (# wind directions, # wind speeds, # turbines, grid resolution, grid resolution)
+    # (# samples, # turbines, grid resolution, grid resolution)
 
     if ix_filter is not None:
         velocities = velocities[:, ix_filter]

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -245,19 +245,19 @@ def Ct(
     wind speed table using the rotor swept area average velocity.
 
     Args:
-        velocities (NDArrayFloat[sample, turbines, grid1, grid2]): The velocity field at
+        velocities (NDArrayFloat[findex, turbines, grid1, grid2]): The velocity field at
             a turbine.
-        yaw_angle (NDArrayFloat[sample, turbines]): The yaw angle for each turbine.
-        tilt_angle (NDArrayFloat[sample, turbines]): The tilt angle for each turbine.
-        ref_tilt_cp_ct (NDArrayFloat[sample, turbines]): The reference tilt angle for each turbine
+        yaw_angle (NDArrayFloat[findex, turbines]): The yaw angle for each turbine.
+        tilt_angle (NDArrayFloat[findex, turbines]): The tilt angle for each turbine.
+        ref_tilt_cp_ct (NDArrayFloat[findex, turbines]): The reference tilt angle for each turbine
             that the Cp/Ct tables are defined at.
         fCt (dict): The thrust coefficient interpolation functions for each turbine. Keys are
             the turbine type string and values are the interpolation functions.
         tilt_interp (Iterable[tuple]): The tilt interpolation functions for each
             turbine.
-        correct_cp_ct_for_tilt (NDArrayBool[sample, turbines]): Boolean for determining if the
+        correct_cp_ct_for_tilt (NDArrayBool[findex, turbines]): Boolean for determining if the
             turbines Cp and Ct should be corrected for tilt.
-        turbine_type_map: (NDArrayObject[sample, turbines]): The Turbine type definition
+        turbine_type_map: (NDArrayObject[findex, turbines]): The Turbine type definition
             for each turbine.
         ix_filter (NDArrayFilter | Iterable[int] | None, optional): The boolean array, or
             integer indices as an iterable of array to filter out before calculation.
@@ -315,14 +315,14 @@ def Ct(
 
 
 def axial_induction(
-    velocities: NDArrayFloat,  # (samples, turbines, grid, grid)
-    yaw_angle: NDArrayFloat,  # (samples, turbines)
-    tilt_angle: NDArrayFloat,  # (samples, turbines)
+    velocities: NDArrayFloat,  # (findex, turbines, grid, grid)
+    yaw_angle: NDArrayFloat,  # (findex, turbines)
+    tilt_angle: NDArrayFloat,  # (findex, turbines)
     ref_tilt_cp_ct: NDArrayFloat,
     fCt: dict,  # (turbines)
     tilt_interp: NDArrayObject,  # (turbines)
-    correct_cp_ct_for_tilt: NDArrayBool, # (samples, turbines)
-    turbine_type_map: NDArrayObject, # (samples, turbines)
+    correct_cp_ct_for_tilt: NDArrayBool, # (findex, turbines)
+    turbine_type_map: NDArrayObject, # (findex, turbines)
     ix_filter: NDArrayFilter | Iterable[int] | None = None,
     average_method: str = "cubic-mean",
     cubature_weights: NDArrayFloat | None = None
@@ -333,17 +333,17 @@ def axial_induction(
     Args:
         velocities (NDArrayFloat): The velocity field at each turbine; should be shape:
             (number of turbines, ngrid, ngrid), or (ngrid, ngrid) for a single turbine.
-        yaw_angle (NDArrayFloat[samples, turbines]): The yaw angle for each turbine.
-        tilt_angle (NDArrayFloat[samples, turbines]): The tilt angle for each turbine.
-        ref_tilt_cp_ct (NDArrayFloat[samples, turbines]): The reference tilt angle for each turbine
+        yaw_angle (NDArrayFloat[findex, turbines]): The yaw angle for each turbine.
+        tilt_angle (NDArrayFloat[findex, turbines]): The tilt angle for each turbine.
+        ref_tilt_cp_ct (NDArrayFloat[findex, turbines]): The reference tilt angle for each turbine
             that the Cp/Ct tables are defined at.
         fCt (dict): The thrust coefficient interpolation functions for each turbine. Keys are
             the turbine type string and values are the interpolation functions.
         tilt_interp (Iterable[tuple]): The tilt interpolation functions for each
             turbine.
-        correct_cp_ct_for_tilt (NDArrayBool[samples, turbines]): Boolean for determining if the
+        correct_cp_ct_for_tilt (NDArrayBool[findex, turbines]): Boolean for determining if the
             turbines Cp and Ct should be corrected for tilt.
-        turbine_type_map: (NDArrayObject[samples, turbines]): The Turbine type definition
+        turbine_type_map: (NDArrayObject[findex, turbines]): The Turbine type definition
             for each turbine.
         ix_filter (NDArrayFilter | Iterable[int] | None, optional): The boolean array, or
             integer indices (as an array or iterable) to filter out before calculation.
@@ -445,7 +445,7 @@ def average_velocity(
     """
 
     # The input velocities are expected to be a 5 dimensional array with shape:
-    # (# samples, # turbines, grid resolution, grid resolution)
+    # (# findex, # turbines, grid resolution, grid resolution)
 
     if ix_filter is not None:
         velocities = velocities[:, ix_filter]

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -403,13 +403,13 @@ def cubic_mean(array, axis=0):
 def simple_cubature(array, cubature_weights, axis=0):
     weights = cubature_weights.flatten()
     weights = weights * len(weights) / np.sum(weights)
-    product = (array * weights[None, None, None, :, None])
+    product = (array * weights[None, None, :, None])
     return simple_mean(product, axis)
 
 def cubic_cubature(array, cubature_weights, axis=0):
     weights = cubature_weights.flatten()
     weights = weights * len(weights) / np.sum(weights)
-    return np.cbrt(np.mean((array**3.0 * weights[None, None, None, :, None]), axis=axis))
+    return np.cbrt(np.mean((array**3.0 * weights[None, None, :, None]), axis=axis))
 
 def average_velocity(
     velocities: NDArrayFloat,

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -139,7 +139,7 @@ def rotor_effective_velocity(
         ref_tilt_cp_ct = ref_tilt_cp_ct[:, :, ix_filter]
         pP = pP[:, :, ix_filter]
         pT = pT[:, :, ix_filter]
-        turbine_type_map = turbine_type_map[:, :, ix_filter]
+        turbine_type_map = turbine_type_map[:, ix_filter]
 
     # Compute the rotor effective velocity adjusting for air density
     # TODO: This correction is currently split across two functions: this one and `power`, where in
@@ -210,7 +210,7 @@ def power(
     # Down-select inputs if ix_filter is given
     if ix_filter is not None:
         rotor_effective_velocities = rotor_effective_velocities[:, :, ix_filter]
-        turbine_type_map = turbine_type_map[:, :, ix_filter]
+        turbine_type_map = turbine_type_map[:, ix_filter]
 
     # Loop over each turbine type given to get power for all turbines
     p = np.zeros(np.shape(rotor_effective_velocities))

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -315,14 +315,14 @@ def Ct(
 
 
 def axial_induction(
-    velocities: NDArrayFloat,  # (wind directions, wind speeds, turbines, grid, grid)
-    yaw_angle: NDArrayFloat,  # (wind directions, wind speeds, turbines)
-    tilt_angle: NDArrayFloat,  # (wind directions, wind speeds, turbines)
+    velocities: NDArrayFloat,  # (samples, turbines, grid, grid)
+    yaw_angle: NDArrayFloat,  # (samples, turbines)
+    tilt_angle: NDArrayFloat,  # (samples, turbines)
     ref_tilt_cp_ct: NDArrayFloat,
     fCt: dict,  # (turbines)
     tilt_interp: NDArrayObject,  # (turbines)
-    correct_cp_ct_for_tilt: NDArrayBool, # (wind directions, wind speeds, turbines)
-    turbine_type_map: NDArrayObject, # (wind directions, 1, turbines)
+    correct_cp_ct_for_tilt: NDArrayBool, # (samples, turbines)
+    turbine_type_map: NDArrayObject, # (samples, turbines)
     ix_filter: NDArrayFilter | Iterable[int] | None = None,
     average_method: str = "cubic-mean",
     cubature_weights: NDArrayFloat | None = None
@@ -333,17 +333,17 @@ def axial_induction(
     Args:
         velocities (NDArrayFloat): The velocity field at each turbine; should be shape:
             (number of turbines, ngrid, ngrid), or (ngrid, ngrid) for a single turbine.
-        yaw_angle (NDArrayFloat[wd, ws, turbines]): The yaw angle for each turbine.
-        tilt_angle (NDArrayFloat[wd, ws, turbines]): The tilt angle for each turbine.
-        ref_tilt_cp_ct (NDArrayFloat[wd, ws, turbines]): The reference tilt angle for each turbine
+        yaw_angle (NDArrayFloat[samples, turbines]): The yaw angle for each turbine.
+        tilt_angle (NDArrayFloat[samples, turbines]): The tilt angle for each turbine.
+        ref_tilt_cp_ct (NDArrayFloat[samples, turbines]): The reference tilt angle for each turbine
             that the Cp/Ct tables are defined at.
         fCt (dict): The thrust coefficient interpolation functions for each turbine. Keys are
             the turbine type string and values are the interpolation functions.
         tilt_interp (Iterable[tuple]): The tilt interpolation functions for each
             turbine.
-        correct_cp_ct_for_tilt (NDArrayBool[wd, ws, turbines]): Boolean for determining if the
+        correct_cp_ct_for_tilt (NDArrayBool[samples, turbines]): Boolean for determining if the
             turbines Cp and Ct should be corrected for tilt.
-        turbine_type_map: (NDArrayObject[wd, ws, turbines]): The Turbine type definition
+        turbine_type_map: (NDArrayObject[samples, turbines]): The Turbine type definition
             for each turbine.
         ix_filter (NDArrayFilter | Iterable[int] | None, optional): The boolean array, or
             integer indices (as an array or iterable) to filter out before calculation.
@@ -378,9 +378,9 @@ def axial_induction(
 
     # Then, process the input arguments as needed for this function
     if ix_filter is not None:
-        yaw_angle = yaw_angle[:, :, ix_filter]
-        tilt_angle = tilt_angle[:, :, ix_filter]
-        ref_tilt_cp_ct = ref_tilt_cp_ct[:, :, ix_filter]
+        yaw_angle = yaw_angle[:, ix_filter]
+        tilt_angle = tilt_angle[:, ix_filter]
+        ref_tilt_cp_ct = ref_tilt_cp_ct[:, ix_filter]
 
     return (
         0.5

--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -189,8 +189,6 @@ def reverse_rotate_coordinates_rel_west(
 
     Args:
         wind_directions (NDArrayFloat): Series of wind directions to base the rotation.
-        coordinates (NDArrayFloat): Series of coordinates to rotate with shape (N coordinates, 3)
-            so that each element of the array coordinates[i] yields a three-component coordinate.
         grid_x (NDArrayFloat): X-coordinates to be rotated.
         grid_y (NDArrayFloat): Y-coordinates to be rotated.
         grid_z (NDArrayFloat): Z-coordinates to be rotated.

--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -146,7 +146,7 @@ def rotate_coordinates_rel_west(
 
     # Calculate the difference in given wind direction from 270 / West
     wind_deviation_from_west = wind_delta(wind_directions)
-    wind_deviation_from_west = np.reshape(wind_deviation_from_west, (len(wind_directions), 1, 1))
+    wind_deviation_from_west = np.reshape(wind_deviation_from_west, (len(wind_directions), 1))
 
     # Construct the arrays storing the turbine locations
     x_coordinates, y_coordinates, z_coordinates = coordinates.T
@@ -206,9 +206,9 @@ def reverse_rotate_coordinates_rel_west(
     grid_y_reversed = np.zeros_like(grid_x)
     grid_z_reversed = np.zeros_like(grid_x)
     for wii, angle_rotation in enumerate(wind_deviation_from_west):
-        x_rot = grid_x[wii, :, :, :, :]
-        y_rot = grid_y[wii, :, :, :, :]
-        z_rot = grid_z[wii, :, :, :, :]
+        x_rot = grid_x[wii]
+        y_rot = grid_y[wii]
+        z_rot = grid_z[wii]
 
         # Rotate turbine coordinates about the center
         x_rot_offset = x_rot - x_center_of_rotation
@@ -225,9 +225,9 @@ def reverse_rotate_coordinates_rel_west(
         )
         z = z_rot  # Nothing changed in this rotation
 
-        grid_x_reversed[wii, :, :, :, :] = x
-        grid_y_reversed[wii, :, :, :, :] = y
-        grid_z_reversed[wii, :, :, :, :] = z
+        grid_x_reversed[wii] = x
+        grid_y_reversed[wii] = y
+        grid_z_reversed[wii] = z
 
     return grid_x_reversed, grid_y_reversed, grid_z_reversed
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,17 +72,21 @@ def print_test_values(
 
 WIND_DIRECTIONS = [
     270.0,
-    270.0,
     360.0,
-    360.0,
+    285.0,
+    315.0,
 ]
 
 WIND_SPEEDS = [
     8.0,
+    9.0,
     10.0,
-    8.0,
-    10.0,
+    11.0,
 ]
+
+# Note since len(WIND_DIRECTIONS) == len(WIND_SPEEDS)
+# Could use either
+N_FINDEX = len(WIND_DIRECTIONS)
 
 # Note since len(WIND_DIRECTIONS) == len(WIND_SPEEDS)
 # Could use either
@@ -128,7 +132,7 @@ def turbine_grid_fixture(sample_inputs_fixture) -> TurbineGrid:
         grid_resolution=TURBINE_GRID_RESOLUTION,
         time_series=TIME_SERIES
     )
-
+    rotor_diameters = ROTOR_DIAMETER * np.ones( (N_FINDEX, N_TURBINES) )
 @pytest.fixture
 def flow_field_grid_fixture(sample_inputs_fixture) -> FlowFieldGrid:
     turbine_coordinates = np.array(list(zip(X_COORDS, Y_COORDS, Z_COORDS)))
@@ -140,7 +144,7 @@ def flow_field_grid_fixture(sample_inputs_fixture) -> FlowFieldGrid:
         wind_speeds=np.array(WIND_SPEEDS),
         grid_resolution=[3,2,2]
     )
-
+    rotor_diameters = ROTOR_DIAMETER * np.ones( (N_FINDEX, N_TURBINES) )
 @pytest.fixture
 def points_grid_fixture(sample_inputs_fixture) -> PointsGrid:
     turbine_coordinates = np.array(list(zip(X_COORDS, Y_COORDS, Z_COORDS)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,19 +72,22 @@ def print_test_values(
 
 WIND_DIRECTIONS = [
     270.0,
+    270.0,
     360.0,
-    285.0,
-    315.0,
+    360.0,
 ]
-N_WIND_DIRECTIONS = len(WIND_DIRECTIONS)
+
 WIND_SPEEDS = [
     8.0,
-    9.0,
     10.0,
-    11.0,
+    8.0,
+    10.0,
 ]
-N_WIND_SPEEDS = len(WIND_SPEEDS)
-N_FINDEX = N_WIND_SPEEDS
+
+# Note since len(WIND_DIRECTIONS) == len(WIND_SPEEDS)
+# Could use either
+N_FINDEX = len(WIND_DIRECTIONS)
+
 X_COORDS = [
     0.0,
     5 * 126.0,
@@ -129,7 +132,7 @@ def turbine_grid_fixture(sample_inputs_fixture) -> TurbineGrid:
 @pytest.fixture
 def flow_field_grid_fixture(sample_inputs_fixture) -> FlowFieldGrid:
     turbine_coordinates = np.array(list(zip(X_COORDS, Y_COORDS, Z_COORDS)))
-    rotor_diameters = ROTOR_DIAMETER * np.ones( (N_WIND_DIRECTIONS, N_WIND_SPEEDS, N_TURBINES) )
+    rotor_diameters = ROTOR_DIAMETER * np.ones( (N_FINDEX, N_TURBINES) )
     return FlowFieldGrid(
         turbine_coordinates=turbine_coordinates,
         turbine_diameters=rotor_diameters,
@@ -141,7 +144,7 @@ def flow_field_grid_fixture(sample_inputs_fixture) -> FlowFieldGrid:
 @pytest.fixture
 def points_grid_fixture(sample_inputs_fixture) -> PointsGrid:
     turbine_coordinates = np.array(list(zip(X_COORDS, Y_COORDS, Z_COORDS)))
-    rotor_diameters = ROTOR_DIAMETER * np.ones( (N_WIND_DIRECTIONS, N_WIND_SPEEDS, N_TURBINES) )
+    rotor_diameters = ROTOR_DIAMETER * np.ones( (N_FINDEX, N_TURBINES) )
     points_x = [0.0, 10.0]
     points_y = [0.0, 0.0]
     points_z = [1.0, 2.0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,7 @@ WIND_SPEEDS = [
     11.0,
 ]
 N_WIND_SPEEDS = len(WIND_SPEEDS)
+N_FINDEX = N_WIND_SPEEDS
 X_COORDS = [
     0.0,
     5 * 126.0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,6 @@ WIND_DIRECTIONS = [
     285.0,
     315.0,
 ]
-
 WIND_SPEEDS = [
     8.0,
     9.0,
@@ -84,8 +83,8 @@ WIND_SPEEDS = [
     11.0,
 ]
 
-# Note since len(WIND_DIRECTIONS) == len(WIND_SPEEDS)
-# Could use either
+# FINDEX is the length of the number of conditions, so it can be
+# len(WIND_DIRECTIONS) or len(WIND_SPEEDS
 N_FINDEX = len(WIND_DIRECTIONS)
 
 X_COORDS = [
@@ -128,7 +127,7 @@ def turbine_grid_fixture(sample_inputs_fixture) -> TurbineGrid:
         grid_resolution=TURBINE_GRID_RESOLUTION,
         time_series=TIME_SERIES
     )
-    rotor_diameters = ROTOR_DIAMETER * np.ones( (N_FINDEX, N_TURBINES) )
+
 @pytest.fixture
 def flow_field_grid_fixture(sample_inputs_fixture) -> FlowFieldGrid:
     turbine_coordinates = np.array(list(zip(X_COORDS, Y_COORDS, Z_COORDS)))
@@ -140,7 +139,7 @@ def flow_field_grid_fixture(sample_inputs_fixture) -> FlowFieldGrid:
         wind_speeds=np.array(WIND_SPEEDS),
         grid_resolution=[3,2,2]
     )
-    rotor_diameters = ROTOR_DIAMETER * np.ones( (N_FINDEX, N_TURBINES) )
+
 @pytest.fixture
 def points_grid_fixture(sample_inputs_fixture) -> PointsGrid:
     turbine_coordinates = np.array(list(zip(X_COORDS, Y_COORDS, Z_COORDS)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,10 +88,6 @@ WIND_SPEEDS = [
 # Could use either
 N_FINDEX = len(WIND_DIRECTIONS)
 
-# Note since len(WIND_DIRECTIONS) == len(WIND_SPEEDS)
-# Could use either
-N_FINDEX = len(WIND_DIRECTIONS)
-
 X_COORDS = [
     0.0,
     5 * 126.0,

--- a/tests/farm_unit_test.py
+++ b/tests/farm_unit_test.py
@@ -20,10 +20,9 @@ import pytest
 
 from floris.simulation import Farm
 from floris.utilities import load_yaml
-from tests.conftest import (
+from tests.conftest import (  # N_WIND_DIRECTIONS,; N_WIND_SPEEDS,
+    N_FINDEX,
     N_TURBINES,
-    N_WIND_DIRECTIONS,
-    N_WIND_SPEEDS,
     SampleInputs,
 )
 
@@ -49,7 +48,7 @@ def test_farm_init_homogenous_turbines():
     # turbine_type=[turbine_data["turbine_type"]]
 
     farm.construct_hub_heights()
-    farm.set_yaw_angles(N_WIND_DIRECTIONS, N_WIND_SPEEDS)
+    farm.set_yaw_angles(N_FINDEX)
 
     # Check initial values
     np.testing.assert_array_equal(farm.coordinates, coordinates)
@@ -61,15 +60,15 @@ def test_asdict(sample_inputs_fixture: SampleInputs):
     farm = Farm.from_dict(sample_inputs_fixture.farm)
     farm.construct_hub_heights()
     farm.construct_turbine_ref_tilt_cp_cts()
-    farm.set_yaw_angles(N_WIND_DIRECTIONS, N_WIND_SPEEDS)
-    farm.set_tilt_to_ref_tilt(N_WIND_DIRECTIONS, N_WIND_SPEEDS)
+    farm.set_yaw_angles(N_FINDEX)
+    farm.set_tilt_to_ref_tilt(N_FINDEX)
     dict1 = farm.as_dict()
 
     new_farm = farm.from_dict(dict1)
     new_farm.construct_hub_heights()
     new_farm.construct_turbine_ref_tilt_cp_cts()
-    new_farm.set_yaw_angles(N_WIND_DIRECTIONS, N_WIND_SPEEDS)
-    new_farm.set_tilt_to_ref_tilt(N_WIND_DIRECTIONS, N_WIND_SPEEDS)
+    new_farm.set_yaw_angles(N_FINDEX)
+    new_farm.set_tilt_to_ref_tilt(N_FINDEX)
     dict2 = new_farm.as_dict()
 
     assert dict1 == dict2

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -462,8 +462,8 @@ def test_rotor_velocity_yaw_correction():
 def test_rotor_velocity_tilt_correction():
     N_TURBINES = 4
 
-    wind_speed = average_velocity(10.0 * np.ones((1, 1, 1, 3, 3)))
-    wind_speed_N_TURBINES = average_velocity(10.0 * np.ones((1, 1, N_TURBINES, 3, 3)))
+    wind_speed = average_velocity(10.0 * np.ones((1, 1, 3, 3)))
+    wind_speed_N_TURBINES = average_velocity(10.0 * np.ones((1, N_TURBINES, 3, 3)))
 
     turbine_data = SampleInputs().turbine
     turbine_floating_data = SampleInputs().turbine_floating
@@ -475,11 +475,11 @@ def test_rotor_velocity_tilt_correction():
     # Test single non-floating turbine
     tilt_corrected_velocities = _rotor_velocity_tilt_correction(
         turbine_type_map=np.array([turbine_type_map[:, 0]]),
-        tilt_angle=5.0*np.ones((1, 1, 1)),
+        tilt_angle=5.0*np.ones((1, 1)),
         ref_tilt_cp_ct=np.array([turbine.ref_tilt_cp_ct]),
         pT=np.array([turbine.pT]),
         tilt_interp=np.array([(turbine.turbine_type, turbine.fTilt_interp)]),
-        correct_cp_ct_for_tilt=np.array([[[False]]]),
+        correct_cp_ct_for_tilt=np.array([[False]]),
         rotor_effective_velocities=wind_speed,
     )
 
@@ -488,11 +488,11 @@ def test_rotor_velocity_tilt_correction():
     # Test multiple non-floating turbines
     tilt_corrected_velocities = _rotor_velocity_tilt_correction(
         turbine_type_map=turbine_type_map,
-        tilt_angle=5.0*np.ones((1, 1, N_TURBINES)),
+        tilt_angle=5.0*np.ones((1, N_TURBINES)),
         ref_tilt_cp_ct=np.array([turbine.ref_tilt_cp_ct] * N_TURBINES),
         pT=np.array([turbine.pT] * N_TURBINES),
         tilt_interp=np.array([(turbine.turbine_type, turbine.fTilt_interp)] * N_TURBINES),
-        correct_cp_ct_for_tilt=np.array([[[False] * N_TURBINES]]),
+        correct_cp_ct_for_tilt=np.array([[False] * N_TURBINES]),
         rotor_effective_velocities=wind_speed_N_TURBINES,
     )
 
@@ -501,11 +501,11 @@ def test_rotor_velocity_tilt_correction():
     # Test single floating turbine
     tilt_corrected_velocities = _rotor_velocity_tilt_correction(
         turbine_type_map=np.array([turbine_type_map[:, 0]]),
-        tilt_angle=5.0*np.ones((1, 1, 1)),
+        tilt_angle=5.0*np.ones((1, 1)),
         ref_tilt_cp_ct=np.array([turbine_floating.ref_tilt_cp_ct]),
         pT=np.array([turbine_floating.pT]),
         tilt_interp=np.array([(turbine_floating.turbine_type, turbine_floating.fTilt_interp)]),
-        correct_cp_ct_for_tilt=np.array([[[True]]]),
+        correct_cp_ct_for_tilt=np.array([[True]]),
         rotor_effective_velocities=wind_speed,
     )
 
@@ -514,13 +514,13 @@ def test_rotor_velocity_tilt_correction():
     # Test multiple floating turbines
     tilt_corrected_velocities = _rotor_velocity_tilt_correction(
         turbine_type_map,
-        tilt_angle=5.0*np.ones((1, 1, N_TURBINES)),
+        tilt_angle=5.0*np.ones((1, N_TURBINES)),
         ref_tilt_cp_ct=np.array([turbine_floating.ref_tilt_cp_ct] * N_TURBINES),
         pT=np.array([turbine_floating.pT] * N_TURBINES),
         tilt_interp=np.array(
             [(turbine_floating.turbine_type, turbine_floating.fTilt_interp)] * N_TURBINES
         ),
-        correct_cp_ct_for_tilt=np.array([[[True] * N_TURBINES]]),
+        correct_cp_ct_for_tilt=np.array([[True] * N_TURBINES]),
         rotor_effective_velocities=wind_speed_N_TURBINES,
     )
 

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -37,7 +37,7 @@ from tests.conftest import SampleInputs, WIND_SPEEDS
 
 
 # size 12 x 1 x 1 x 1
-# (in previous version stack was used in place of conatenate,
+# (in previous version stack was used in place of concatenate,
 # yielding 3 x 4 x 1 x 1 x 1 )
 WIND_CONDITION_BROADCAST = np.concatenate(
     (

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -423,8 +423,8 @@ def test_axial_induction():
 def test_rotor_velocity_yaw_correction():
     N_TURBINES = 4
 
-    wind_speed = average_velocity(10.0 * np.ones((1, 1, 1, 3, 3)))
-    wind_speed_N_TURBINES = average_velocity(10.0 * np.ones((1, 1, N_TURBINES, 3, 3)))
+    wind_speed = average_velocity(10.0 * np.ones((1, 1, 3, 3)))
+    wind_speed_N_TURBINES = average_velocity(10.0 * np.ones((1, N_TURBINES, 3, 3)))
 
     # Test a single turbine for zero yaw
     yaw_corrected_velocities = _rotor_velocity_yaw_correction(
@@ -445,7 +445,7 @@ def test_rotor_velocity_yaw_correction():
     # Test multiple turbines for zero yaw
     yaw_corrected_velocities = _rotor_velocity_yaw_correction(
         pP=3.0,
-        yaw_angle=np.zeros((1, 1, N_TURBINES)),
+        yaw_angle=np.zeros((1, N_TURBINES)),
         rotor_effective_velocities=wind_speed_N_TURBINES,
     )
     np.testing.assert_allclose(yaw_corrected_velocities, wind_speed_N_TURBINES)
@@ -453,7 +453,7 @@ def test_rotor_velocity_yaw_correction():
     # Test multiple turbines for non-zero yaw
     yaw_corrected_velocities = _rotor_velocity_yaw_correction(
         pP=3.0,
-        yaw_angle=np.ones((1, 1, N_TURBINES)) * 60.0,
+        yaw_angle=np.ones((1, N_TURBINES)) * 60.0,
         rotor_effective_velocities=wind_speed_N_TURBINES,
     )
     np.testing.assert_allclose(yaw_corrected_velocities, 0.5 * wind_speed_N_TURBINES)

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -602,3 +602,23 @@ def test_simple_cubature():
 
     # Check if the result matches the expected output
     np.testing.assert_allclose(result, expected_output)
+
+def test_cubic_cubature():
+
+    # Define a sample array
+    velocities = np.ones((1, 1, 1, 3, 3))
+
+    # Define sample cubature weights
+    cubature_weights = np.array([1., 1., 1.])
+
+    # Define the axis as last 2 dimensions
+    axis = (velocities.ndim-2, velocities.ndim-1)
+
+    # Calculate expected output based on the given inputs
+    expected_output = 1.0
+
+    # Call the function with the given inputs
+    result = cubic_cubature(velocities, cubature_weights, axis)
+
+    # Check if the result matches the expected output
+    np.testing.assert_allclose(result, expected_output)

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -29,7 +29,9 @@ from floris.simulation.turbine import (
     _rotor_velocity_tilt_correction,
     _rotor_velocity_yaw_correction,
     compute_tilt_angles_for_floating_turbines,
+    cubic_cubature,
     PowerThrustTable,
+    simple_cubature,
 )
 from tests.conftest import SampleInputs, WIND_SPEEDS
 
@@ -579,3 +581,24 @@ def test_asdict(sample_inputs_fixture: SampleInputs):
     dict2 = new_turb.as_dict()
 
     assert dict1 == dict2
+
+
+def test_simple_cubature():
+
+    # Define a sample array
+    velocities = np.ones((1, 1, 1, 3, 3))
+
+    # Define sample cubature weights
+    cubature_weights = np.array([1., 1., 1.])
+
+    # Define the axis as last 2 dimensions
+    axis = (velocities.ndim-2, velocities.ndim-1)
+
+    # Calculate expected output based on the given inputs
+    expected_output = 1.0
+
+    # Call the function with the given inputs
+    result = simple_cubature(velocities, cubature_weights, axis)
+
+    # Check if the result matches the expected output
+    np.testing.assert_allclose(result, expected_output)

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -323,7 +323,7 @@ def test_power():
     turbine_data = SampleInputs().turbine
     turbine = Turbine.from_dict(turbine_data)
     turbine_type_map = np.array(n_turbines * [turbine.turbine_type])
-    turbine_type_map = turbine_type_map[None, None, :]
+    turbine_type_map = turbine_type_map[None, :]
     test_4_power = power(
         ref_density_cp_ct=AIR_DENSITY,
         rotor_effective_velocities=wind_speed * np.ones((1, 1, n_turbines)),
@@ -339,12 +339,12 @@ def test_power():
     turbine_data = SampleInputs().turbine
     turbine = Turbine.from_dict(turbine_data)
     turbine_type_map = np.array(n_turbines * [turbine.turbine_type])
-    turbine_type_map = turbine_type_map[None, None, :]
+    turbine_type_map = turbine_type_map[None, :]
     test_grid_power = power(
         ref_density_cp_ct=AIR_DENSITY,
         rotor_effective_velocities=wind_speed * np.ones((1, 1, n_turbines, 3, 3)),
         power_interp={turbine.turbine_type: turbine.power_interp},
-        turbine_type_map=turbine_type_map[:,:,0]
+        turbine_type_map=turbine_type_map[:,0]
     )
     baseline_grid_power = baseline_power * np.ones((1, 1, n_turbines, 3, 3))
     assert np.allclose(baseline_grid_power, test_grid_power)

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -36,19 +36,9 @@ from floris.simulation.turbine import (
 from tests.conftest import SampleInputs, WIND_SPEEDS
 
 
-# This was the version when 0,1 dimensions were wd, ws
-# size 3 x 4 x 1 x 1 x 1
-# WIND_CONDITION_BROADCAST = np.stack(
-#     (
-#         np.reshape(np.array(WIND_SPEEDS), (-1, 1, 1, 1)),  # Wind direction 0
-#         np.reshape(np.array(WIND_SPEEDS), (-1, 1, 1, 1)),  # Wind direction 1
-#         np.reshape(np.array(WIND_SPEEDS), (-1, 1, 1, 1)),  # Wind direction 2
-#     ),
-#     axis=0,
-# )
-
-# This was the version when 0 dimension is findex
 # size 12 x 1 x 1 x 1
+# (in previous version stack was used in place of conatenate,
+# yielding 3 x 4 x 1 x 1 x 1 )
 WIND_CONDITION_BROADCAST = np.concatenate(
     (
         np.reshape(np.array(WIND_SPEEDS), (-1, 1, 1, 1)),  # Wind direction 0
@@ -57,8 +47,6 @@ WIND_CONDITION_BROADCAST = np.concatenate(
     ),
     axis=0,
 )
-
-
 INDEX_FILTER = [0, 2]
 
 

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -301,7 +301,7 @@ def test_power():
         ref_density_cp_ct=AIR_DENSITY,
         rotor_effective_velocities=wind_speed * np.ones((1, 1, 1)),
         power_interp={turbine.turbine_type: turbine.power_interp},
-        turbine_type_map=turbine_type_map[:,:,0]
+        turbine_type_map=turbine_type_map[:,0]
     )
     assert np.allclose(rated_power, 5e6)
 
@@ -312,7 +312,7 @@ def test_power():
         ref_density_cp_ct=AIR_DENSITY,
         rotor_effective_velocities=wind_speed * np.ones((1, 1, 1)),
         power_interp={turbine.turbine_type: turbine.power_interp},
-        turbine_type_map=turbine_type_map[:,:,0]
+        turbine_type_map=turbine_type_map[:,0]
     )
     assert np.allclose(zero_power, 0.0)
 

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -531,9 +531,9 @@ def test_compute_tilt_angles_for_floating_turbines():
     N_TURBINES = 4
 
     wind_speed = 25.0
-    rotor_effective_velocities = average_velocity(wind_speed * np.ones((1, 1, 1, 3, 3)))
+    rotor_effective_velocities = average_velocity(wind_speed * np.ones((1, 1, 3, 3)))
     rotor_effective_velocities_N_TURBINES = average_velocity(
-        wind_speed * np.ones((1, 1, N_TURBINES, 3, 3))
+        wind_speed * np.ones((1, N_TURBINES, 3, 3))
     )
 
     turbine_floating_data = SampleInputs().turbine_floating
@@ -544,7 +544,7 @@ def test_compute_tilt_angles_for_floating_turbines():
     # Single turbine
     tilt = compute_tilt_angles_for_floating_turbines(
         turbine_type_map=np.array([turbine_type_map[:, 0]]),
-        tilt_angle=5.0*np.ones((1, 1, 1)),
+        tilt_angle=5.0*np.ones((1, 1)),
         tilt_interp=np.array([(turbine_floating.turbine_type, turbine_floating.fTilt_interp)]),
         rotor_effective_velocities=rotor_effective_velocities,
     )
@@ -557,7 +557,7 @@ def test_compute_tilt_angles_for_floating_turbines():
     # Mulitple turbines
     tilt_N_turbines = compute_tilt_angles_for_floating_turbines(
         turbine_type_map=np.array(turbine_type_map),
-        tilt_angle=5.0*np.ones((1, 1, N_TURBINES)),
+        tilt_angle=5.0*np.ones((1, N_TURBINES)),
         tilt_interp=np.array(
             [(turbine_floating.turbine_type, turbine_floating.fTilt_interp)] * N_TURBINES
         ),
@@ -567,7 +567,7 @@ def test_compute_tilt_angles_for_floating_turbines():
     # calculate tilt again
     truth_index = turbine_floating_data["floating_tilt_table"]["wind_speeds"].index(wind_speed)
     tilt_truth = turbine_floating_data["floating_tilt_table"]["tilt"][truth_index]
-    np.testing.assert_allclose(tilt_N_turbines, [[[tilt_truth] * N_TURBINES]])
+    np.testing.assert_allclose(tilt_N_turbines, [[tilt_truth] * N_TURBINES])
 
 
 def test_asdict(sample_inputs_fixture: SampleInputs):

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -586,7 +586,7 @@ def test_asdict(sample_inputs_fixture: SampleInputs):
 def test_simple_cubature():
 
     # Define a sample array
-    velocities = np.ones((1, 1, 1, 3, 3))
+    velocities = np.ones((1, 1, 3, 3))
 
     # Define sample cubature weights
     cubature_weights = np.array([1., 1., 1.])
@@ -606,7 +606,7 @@ def test_simple_cubature():
 def test_cubic_cubature():
 
     # Define a sample array
-    velocities = np.ones((1, 1, 1, 3, 3))
+    velocities = np.ones((1, 1, 3, 3))
 
     # Define sample cubature weights
     cubature_weights = np.array([1., 1., 1.])

--- a/tests/utilities_unit_test.py
+++ b/tests/utilities_unit_test.py
@@ -93,9 +93,13 @@ def test_rotate_coordinates_rel_west():
         wind_directions, coordinates
     )
 
-    np.testing.assert_array_equal(X_COORDS, x_rotated[0, 0])
-    np.testing.assert_array_equal(Y_COORDS, y_rotated[0, 0])
-    np.testing.assert_array_equal(Z_COORDS, z_rotated[0, 0])
+    # Test that x_rotated has 2 dimensions
+    np.testing.assert_equal(np.ndim(x_rotated), 2)
+
+    # Assert the rotating to 270 doesn't change coordinates
+    np.testing.assert_array_equal(X_COORDS, x_rotated[0])
+    np.testing.assert_array_equal(Y_COORDS, y_rotated[0])
+    np.testing.assert_array_equal(Z_COORDS, z_rotated[0])
 
     # For 360, the coordinates should be rotated 90 degrees counter clockwise
     # from looking fown at the wind farm from above. The series of turbines
@@ -110,19 +114,19 @@ def test_rotate_coordinates_rel_west():
     x_rotated, y_rotated, z_rotated, _, _ = rotate_coordinates_rel_west(
         wind_directions, coordinates
     )
-    np.testing.assert_almost_equal(Y_COORDS, x_rotated[0, 0] - np.min(x_rotated[0, 0]))
-    np.testing.assert_almost_equal(X_COORDS, y_rotated[0, 0] - np.min(y_rotated[0, 0]))
+    np.testing.assert_almost_equal(Y_COORDS, x_rotated[0] - np.min(x_rotated[0]))
+    np.testing.assert_almost_equal(X_COORDS, y_rotated[0] - np.min(y_rotated[0]))
     np.testing.assert_almost_equal(
-        Z_COORDS + np.min(Z_COORDS), z_rotated[0, 0] + np.min(z_rotated[0, 0])
+        Z_COORDS + np.min(Z_COORDS), z_rotated[0] + np.min(z_rotated[0])
     )
 
     wind_directions = np.array([90.0])
     x_rotated, y_rotated, z_rotated, _, _ = rotate_coordinates_rel_west(
         wind_directions, coordinates
     )
-    np.testing.assert_almost_equal(X_COORDS[-1:-4:-1], x_rotated[0, 0])
-    np.testing.assert_almost_equal(Y_COORDS, y_rotated[0, 0])
-    np.testing.assert_almost_equal(Z_COORDS, z_rotated[0, 0])
+    np.testing.assert_almost_equal(X_COORDS[-1:-4:-1], x_rotated[0])
+    np.testing.assert_almost_equal(Y_COORDS, y_rotated[0])
+    np.testing.assert_almost_equal(Z_COORDS, z_rotated[0])
 
 
 def test_reverse_rotate_coordinates_rel_west():
@@ -143,10 +147,10 @@ def test_reverse_rotate_coordinates_rel_west():
         y_center_of_rotation,
     ) = rotate_coordinates_rel_west(wind_directions, coordinates)
 
-    # Go up to 5 dimensions (reverse function is expecting grid)
-    grid_x = x_rotated[:, :, :, None, None]
-    grid_y = y_rotated[:, :, :, None, None]
-    grid_z = z_rotated[:, :, :, None, None]
+    # Go up to 4 dimensions (reverse function is expecting grid)
+    grid_x = x_rotated[:, :,  None, None]
+    grid_y = y_rotated[:, :,  None, None]
+    grid_z = z_rotated[:, :,  None, None]
 
     # Perform reverse rotation
     grid_x_reversed, grid_y_reversed, grid_z_reversed = reverse_rotate_coordinates_rel_west(

--- a/tests/utilities_unit_test.py
+++ b/tests/utilities_unit_test.py
@@ -85,7 +85,7 @@ def test_wind_delta():
 
 
 def test_rotate_coordinates_rel_west():
-    coordinates = np.array([[x, y, z] for x, y, z in zip(X_COORDS, Y_COORDS, Z_COORDS)])
+    coordinates = np.array(list(zip(X_COORDS, Y_COORDS, Z_COORDS)))
 
     # For 270, the coordinates should not change.
     wind_directions = np.array([270.0])

--- a/tests/utilities_unit_test.py
+++ b/tests/utilities_unit_test.py
@@ -90,7 +90,8 @@ def test_rotate_coordinates_rel_west():
     # For 270, the coordinates should not change.
     wind_directions = np.array([270.0])
     x_rotated, y_rotated, z_rotated, _, _ = rotate_coordinates_rel_west(
-        wind_directions, coordinates
+        wind_directions,
+        coordinates
     )
 
     # Test that x_rotated has 2 dimensions
@@ -112,12 +113,14 @@ def test_rotate_coordinates_rel_west():
     # conftest change.
     wind_directions = np.array([360.0])
     x_rotated, y_rotated, z_rotated, _, _ = rotate_coordinates_rel_west(
-        wind_directions, coordinates
+        wind_directions,
+        coordinates
     )
     np.testing.assert_almost_equal(Y_COORDS, x_rotated[0] - np.min(x_rotated[0]))
     np.testing.assert_almost_equal(X_COORDS, y_rotated[0] - np.min(y_rotated[0]))
     np.testing.assert_almost_equal(
-        Z_COORDS + np.min(Z_COORDS), z_rotated[0] + np.min(z_rotated[0])
+        Z_COORDS + np.min(Z_COORDS),
+        z_rotated[0] + np.min(z_rotated[0])
     )
 
     wind_directions = np.array([90.0])

--- a/tests/utilities_unit_test.py
+++ b/tests/utilities_unit_test.py
@@ -13,14 +13,13 @@
 # See https://floris.readthedocs.io for documentation
 
 
-
-
 import attr
 import numpy as np
 import pytest
 
 from floris.utilities import (
     cosd,
+    reverse_rotate_coordinates_rel_west,
     rotate_coordinates_rel_west,
     sind,
     tand,
@@ -86,19 +85,17 @@ def test_wind_delta():
 
 
 def test_rotate_coordinates_rel_west():
-
-    coordinates = np.array([ [x,y,z] for x,y,z in zip(X_COORDS, Y_COORDS, Z_COORDS)])
+    coordinates = np.array([[x, y, z] for x, y, z in zip(X_COORDS, Y_COORDS, Z_COORDS)])
 
     # For 270, the coordinates should not change.
     wind_directions = np.array([270.0])
     x_rotated, y_rotated, z_rotated, _, _ = rotate_coordinates_rel_west(
-        wind_directions,
-        coordinates
+        wind_directions, coordinates
     )
 
-    np.testing.assert_array_equal( X_COORDS, x_rotated[0,0] )
-    np.testing.assert_array_equal( Y_COORDS, y_rotated[0,0] )
-    np.testing.assert_array_equal( Z_COORDS, z_rotated[0,0] )
+    np.testing.assert_array_equal(X_COORDS, x_rotated[0, 0])
+    np.testing.assert_array_equal(Y_COORDS, y_rotated[0, 0])
+    np.testing.assert_array_equal(Z_COORDS, z_rotated[0, 0])
 
     # For 360, the coordinates should be rotated 90 degrees counter clockwise
     # from looking fown at the wind farm from above. The series of turbines
@@ -111,21 +108,56 @@ def test_rotate_coordinates_rel_west():
     # conftest change.
     wind_directions = np.array([360.0])
     x_rotated, y_rotated, z_rotated, _, _ = rotate_coordinates_rel_west(
-        wind_directions,
-        coordinates
+        wind_directions, coordinates
     )
-    np.testing.assert_almost_equal( Y_COORDS, x_rotated[0,0] - np.min(x_rotated[0,0]))
-    np.testing.assert_almost_equal( X_COORDS, y_rotated[0,0] - np.min(y_rotated[0,0]))
+    np.testing.assert_almost_equal(Y_COORDS, x_rotated[0, 0] - np.min(x_rotated[0, 0]))
+    np.testing.assert_almost_equal(X_COORDS, y_rotated[0, 0] - np.min(y_rotated[0, 0]))
     np.testing.assert_almost_equal(
-        Z_COORDS + np.min(Z_COORDS),
-        z_rotated[0,0] + np.min(z_rotated[0,0])
+        Z_COORDS + np.min(Z_COORDS), z_rotated[0, 0] + np.min(z_rotated[0, 0])
     )
 
     wind_directions = np.array([90.0])
     x_rotated, y_rotated, z_rotated, _, _ = rotate_coordinates_rel_west(
-        wind_directions,
-        coordinates
+        wind_directions, coordinates
     )
-    np.testing.assert_almost_equal( X_COORDS[-1:-4:-1], x_rotated[0,0] )
-    np.testing.assert_almost_equal( Y_COORDS, y_rotated[0,0] )
-    np.testing.assert_almost_equal( Z_COORDS, z_rotated[0,0] )
+    np.testing.assert_almost_equal(X_COORDS[-1:-4:-1], x_rotated[0, 0])
+    np.testing.assert_almost_equal(Y_COORDS, y_rotated[0, 0])
+    np.testing.assert_almost_equal(Z_COORDS, z_rotated[0, 0])
+
+
+def test_reverse_rotate_coordinates_rel_west():
+    # Test that appplying the rotation, and then the reverse produces the original coordinates
+
+    # Test the reverse rotation
+    coordinates = np.array([[x, y, z] for x, y, z in zip(X_COORDS, Y_COORDS, Z_COORDS)])
+
+    # Rotate to 360 (as in above function)
+    wind_directions = np.array([360.0])
+
+    # Get the rotated coordinates
+    (
+        x_rotated,
+        y_rotated,
+        z_rotated,
+        x_center_of_rotation,
+        y_center_of_rotation,
+    ) = rotate_coordinates_rel_west(wind_directions, coordinates)
+
+    # Go up to 5 dimensions (reverse function is expecting grid)
+    grid_x = x_rotated[:, :, :, None, None]
+    grid_y = y_rotated[:, :, :, None, None]
+    grid_z = z_rotated[:, :, :, None, None]
+
+    # Perform reverse rotation
+    grid_x_reversed, grid_y_reversed, grid_z_reversed = reverse_rotate_coordinates_rel_west(
+        wind_directions,
+        grid_x,
+        grid_y,
+        grid_z,
+        x_center_of_rotation,
+        y_center_of_rotation,
+    )
+
+    np.testing.assert_almost_equal(grid_x_reversed.squeeze(), coordinates[:,0].squeeze())
+    np.testing.assert_almost_equal(grid_y_reversed.squeeze(), coordinates[:,1].squeeze())
+    np.testing.assert_almost_equal(grid_z_reversed.squeeze(), coordinates[:,2].squeeze())


### PR DESCRIPTION
This pull request is working to implement the change from 5d to 4d in FLORIS files.  Specifically following the implementation plan laid out in:

https://github.com/orgs/NREL/projects/96?pane=issue&itemId=46113814

Going to edit this pull-request as I make progress but so far steps taken are:

- Convert turbine.py to 4d
- Update turbine_unit_test.py to 4d
- (Not addressing turbine_multi_dim.py as @rafmudaf and @bayc are tackling seperately)
- Adding N_FINDEX to conftest
- Updating farm.py to 4d (NOTE EXCLUDING MULTI_DIM BLOCKS)
- Updating farm_unit_test.py to 4d
- Add a unit test for reverse_rotate_coordinates_rel_west
- Convert utilities.py to 4d and convert unit tests to 4d and confirm they pass

@rafmudaf @misi9170 @bayc -- stopping at this point to resync with @rafmudaf before proceeding to grid.py

Note 4d conversion half done so not all tests can pass, however the tests that should pass are:
turbine_unit_test.py
utilities_unit_test.py
farm_unit_test.py

Additional note that farm.py conversion is not complete, that is waiting until after the grid sync.  This code includes commented temporary code and todo notes which will be completed after sync.

- Add unit test for finalize()

Finally, as noted above, code related to multi-dim is excluded and noted as TODO in code