### PR TITLE
Convert EmG model to 4d structure

### DIFF
--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -1274,6 +1274,7 @@ def empirical_gauss_solver(
 
         if model_manager.enable_yaw_added_recovery:
             # Influence of yawing on turbine's own wake
+            # TODO: Create reg test for the case when enable_yaw_added_recovery is True
             mixing_factor[:, i:i+1, i] += \
                 yaw_added_wake_mixing(
                     axial_induction_i,
@@ -1285,7 +1286,7 @@ def empirical_gauss_solver(
         # Extract total wake induced mixing for turbine i
         mixing_i = np.linalg.norm(
             mixing_factor[:, i:i+1, :, None],
-            ord=2, axis=3, keepdims=True
+            ord=2, axis=2, keepdims=True
         )
 
         # Model calculations
@@ -1324,21 +1325,21 @@ def empirical_gauss_solver(
         )
 
         # Calculate wake overlap for wake-added turbulence (WAT)
-        import ipdb; ipdb.set_trace() # AT THIS POINT
-        area_overlap = np.sum(velocity_deficit * flow_field.u_initial_sorted > 0.05, axis=(3, 4))\
+        area_overlap = np.sum(velocity_deficit * flow_field.u_initial_sorted > 0.05, axis=(2, 3))\
             / (grid.grid_resolution * grid.grid_resolution)
 
         # Compute wake induced mixing factor
-        mixing_factor[:,:,:,i] += \
+        mixing_factor[:,:,i] += \
             area_overlap * model_manager.turbulence_model.function(
-                axial_induction_i, downstream_distance_D[:,:,:,i]
+                axial_induction_i, downstream_distance_D[:,:,i]
             )
         if model_manager.enable_yaw_added_recovery:
-            mixing_factor[:,:,:,i] += \
+            # TODO: Create reg test for the case when enable_yaw_added_recovery is True
+            mixing_factor[:,:,i] += \
                 area_overlap * yaw_added_wake_mixing(
                 axial_induction_i,
                 yaw_angle_i,
-                downstream_distance_D[:,:,:,i],
+                downstream_distance_D[:,:,i],
                 model_manager.deflection_model.yaw_added_mixing_gain
             )
 

--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -1274,7 +1274,6 @@ def empirical_gauss_solver(
 
         if model_manager.enable_yaw_added_recovery:
             # Influence of yawing on turbine's own wake
-            # TODO: Create reg test for the case when enable_yaw_added_recovery is True
             mixing_factor[:, i:i+1, i] += \
                 yaw_added_wake_mixing(
                     axial_induction_i,
@@ -1334,7 +1333,6 @@ def empirical_gauss_solver(
                 axial_induction_i, downstream_distance_D[:,:,i]
             )
         if model_manager.enable_yaw_added_recovery:
-            # TODO: Create reg test for the case when enable_yaw_added_recovery is True
             mixing_factor[:,:,i] += \
                 area_overlap * yaw_added_wake_mixing(
                 axial_induction_i,

--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -1188,28 +1188,33 @@ def empirical_gauss_solver(
     v_wake = np.zeros_like(flow_field.v_initial_sorted)
     w_wake = np.zeros_like(flow_field.w_initial_sorted)
 
-    x_locs = np.mean(grid.x_sorted, axis=(3, 4))[:,:,:,None]
-    downstream_distance_D = x_locs - np.transpose(x_locs, axes=(0,1,3,2))
+    x_locs = np.mean(grid.x_sorted, axis=(2, 3))[:,:,None]
+    downstream_distance_D = x_locs - np.transpose(x_locs, axes=(0,2,1))
     downstream_distance_D = downstream_distance_D / \
-        np.repeat(farm.rotor_diameters_sorted[:,:,:,None], grid.n_turbines, axis=-1)
+        np.repeat(farm.rotor_diameters_sorted[:,:,None], grid.n_turbines, axis=-1)
     downstream_distance_D = np.maximum(downstream_distance_D, 0.1) # For ease
-    mixing_factor = np.zeros_like(downstream_distance_D)
-    mixing_factor[:,:,:,:] = model_manager.turbulence_model.atmospheric_ti_gain*\
-        flow_field.turbulence_intensity*np.eye(grid.n_turbines)
+    # Initialize the mixing factor model using TI if specified
+    initial_mixing_factor = model_manager.turbulence_model.atmospheric_ti_gain*\
+            flow_field.turbulence_intensity*np.eye(grid.n_turbines)
+    mixing_factor = np.repeat(
+        initial_mixing_factor[None,:,:],
+        flow_field.n_findex,
+        axis=0
+    )
 
     # Calculate the velocity deficit sequentially from upstream to downstream turbines
     for i in range(grid.n_turbines):
 
         # Get the current turbine quantities
-        x_i = np.mean(grid.x_sorted[:, :, i:i+1], axis=(3, 4))
-        x_i = x_i[:, :, :, None, None]
-        y_i = np.mean(grid.y_sorted[:, :, i:i+1], axis=(3, 4))
-        y_i = y_i[:, :, :, None, None]
-        z_i = np.mean(grid.z_sorted[:, :, i:i+1], axis=(3, 4))
-        z_i = z_i[:, :, :, None, None]
+        x_i = np.mean(grid.x_sorted[:, i:i+1], axis=(2, 3))
+        x_i = x_i[:, :, None, None]
+        y_i = np.mean(grid.y_sorted[:, i:i+1], axis=(2, 3))
+        y_i = y_i[:, :, None, None]
+        z_i = np.mean(grid.z_sorted[:, i:i+1], axis=(2, 3))
+        z_i = z_i[:, :, None, None]
 
-        flow_field.u_sorted[:, :, i:i+1]
-        flow_field.v_sorted[:, :, i:i+1]
+        flow_field.u_sorted[:, i:i+1]
+        flow_field.v_sorted[:, i:i+1]
 
         ct_i = Ct(
             velocities=flow_field.u_sorted,
@@ -1226,7 +1231,7 @@ def empirical_gauss_solver(
         )
         # Since we are filtering for the i'th turbine in the Ct function,
         # get the first index here (0:1)
-        ct_i = ct_i[:, :, 0:1, None, None]
+        ct_i = ct_i[:, 0:1, None, None]
         axial_induction_i = axial_induction(
             velocities=flow_field.u_sorted,
             yaw_angle=farm.yaw_angles_sorted,
@@ -1242,13 +1247,14 @@ def empirical_gauss_solver(
         )
         # Since we are filtering for the i'th turbine in the axial induction function,
         # get the first index here (0:1)
-        axial_induction_i = axial_induction_i[:, :, 0:1, None, None]
-        yaw_angle_i = farm.yaw_angles_sorted[:, :, i:i+1, None, None]
-        hub_height_i = farm.hub_heights_sorted[: ,:, i:i+1, None, None]
-        rotor_diameter_i = farm.rotor_diameters_sorted[: ,:, i:i+1, None, None]
+        axial_induction_i = axial_induction_i[:, 0:1, None, None]
+        yaw_angle_i = farm.yaw_angles_sorted[:, i:i+1, None, None]
+        hub_height_i = farm.hub_heights_sorted[:, i:i+1, None, None]
+        rotor_diameter_i = farm.rotor_diameters_sorted[:, i:i+1, None, None]
 
-        effective_yaw_i = np.zeros_like(yaw_angle_i)
-        effective_yaw_i += yaw_angle_i
+        # Secondary steering not currently implemented in EmGauss model
+        # effective_yaw_i = np.zeros_like(yaw_angle_i)
+        # effective_yaw_i += yaw_angle_i
 
         average_velocities = average_velocity(
             flow_field.u_sorted,
@@ -1256,7 +1262,7 @@ def empirical_gauss_solver(
             cubature_weights=grid.cubature_weights
         )
         tilt_angle_i = farm.calculate_tilt_for_eff_velocities(average_velocities)
-        tilt_angle_i = tilt_angle_i[:, :, i:i+1, None, None]
+        tilt_angle_i = tilt_angle_i[:, i:i+1, None, None]
 
         if model_manager.enable_secondary_steering:
             raise NotImplementedError(
@@ -1268,7 +1274,7 @@ def empirical_gauss_solver(
 
         if model_manager.enable_yaw_added_recovery:
             # Influence of yawing on turbine's own wake
-            mixing_factor[:, :, i:i+1, i] += \
+            mixing_factor[:, i:i+1, i] += \
                 yaw_added_wake_mixing(
                     axial_induction_i,
                     yaw_angle_i,
@@ -1278,7 +1284,7 @@ def empirical_gauss_solver(
 
         # Extract total wake induced mixing for turbine i
         mixing_i = np.linalg.norm(
-            mixing_factor[:, :, i:i+1, :, None],
+            mixing_factor[:, i:i+1, :, None],
             ord=2, axis=3, keepdims=True
         )
 
@@ -1287,7 +1293,7 @@ def empirical_gauss_solver(
         deflection_field_y, deflection_field_z = model_manager.deflection_model.function(
             x_i,
             y_i,
-            effective_yaw_i,
+            yaw_angle_i,
             tilt_angle_i,
             mixing_i,
             ct_i,
@@ -1318,6 +1324,7 @@ def empirical_gauss_solver(
         )
 
         # Calculate wake overlap for wake-added turbulence (WAT)
+        import ipdb; ipdb.set_trace() # AT THIS POINT
         area_overlap = np.sum(velocity_deficit * flow_field.u_initial_sorted > 0.05, axis=(3, 4))\
             / (grid.grid_resolution * grid.grid_resolution)
 

--- a/floris/simulation/wake_deflection/empirical_gauss.py
+++ b/floris/simulation/wake_deflection/empirical_gauss.py
@@ -145,8 +145,8 @@ def yaw_added_wake_mixing(
     yaw_added_mixing_gain
 ):
     return (
-        axial_induction_i[:,:,:,0,0]
+        axial_induction_i[:,:,0,0]
         * yaw_added_mixing_gain
-        * (1 - cosd(yaw_angle_i[:,:,:,0,0]))
+        * (1 - cosd(yaw_angle_i[:,:,0,0]))
         / downstream_distance_D_i**2
     )

--- a/floris/simulation/wake_turbulence/wake_induced_mixing.py
+++ b/floris/simulation/wake_turbulence/wake_induced_mixing.py
@@ -82,6 +82,6 @@ class WakeInducedMixing(BaseModel):
                 the ith turbine.
         """
 
-        wake_induced_mixing = axial_induction_i[:,:,:,0,0] / downstream_distance_D_i**2
+        wake_induced_mixing = axial_induction_i[:,:,0,0] / downstream_distance_D_i**2
 
         return wake_induced_mixing

--- a/floris/simulation/wake_velocity/empirical_gauss.py
+++ b/floris/simulation/wake_velocity/empirical_gauss.py
@@ -170,7 +170,7 @@ class EmpiricalGaussVelocityDeficit(BaseModel):
             self.mixing_gain_velocity * mixing_i,
         )
         sigma_y[upstream_mask] = \
-            np.tile(sigma_y0, np.shape(sigma_y)[2:])[upstream_mask]
+            np.tile(sigma_y0, np.shape(sigma_y)[1:])[upstream_mask]
 
         sigma_z = empirical_gauss_model_wake_width(
             x - x_i,
@@ -181,7 +181,7 @@ class EmpiricalGaussVelocityDeficit(BaseModel):
             self.mixing_gain_velocity * mixing_i,
         )
         sigma_z[upstream_mask] = \
-            np.tile(sigma_z0, np.shape(sigma_z)[2:])[upstream_mask]
+            np.tile(sigma_z0, np.shape(sigma_z)[1:])[upstream_mask]
 
         # 'Standard' wake component
         r, C = rCalt(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,17 +54,19 @@ def print_test_values(
     average_velocities: list,
     thrusts: list,
     powers: list,
-    axial_inductions: list
+    axial_inductions: list,
+    max_findex_print: int | None=None
 ):
-    n_wd, n_ws, n_turb = np.shape(average_velocities)
-    i=0
-    for j in range(n_ws):
+    n_findex, n_turb = np.shape(average_velocities)
+    if max_findex_print is not None:
+        n_findex = min(n_findex, max_findex_print)
+    for i in range(n_findex):
         print("[")
-        for k in range(n_turb):
+        for j in range(n_turb):
             print(
                 "    [{:.7f}, {:.7f}, {:.7f}, {:.7f}],".format(
-                    average_velocities[i,j,k], thrusts[i,j,k], powers[i,j,k],
-                    axial_inductions[i,j,k]
+                    average_velocities[i,j], thrusts[i,j], powers[i,j],
+                    axial_inductions[i,j]
                 )
             )
         print("],")

--- a/tests/reg_tests/empirical_gauss_regression_test.py
+++ b/tests/reg_tests/empirical_gauss_regression_test.py
@@ -117,10 +117,6 @@ def test_regression_tandem(sample_inputs_fixture):
     velocities = floris.flow_field.u
     yaw_angles = floris.farm.yaw_angles
     tilt_angles = floris.farm.tilt_angles
-    ref_tilt_cp_cts = (
-        np.ones((n_findex, n_turbines))
-        * floris.farm.ref_tilt_cp_cts
-    )
     test_results = np.zeros((n_findex, n_turbines, 4))
 
     farm_avg_velocities = average_velocity(
@@ -132,7 +128,7 @@ def test_regression_tandem(sample_inputs_fixture):
         velocities,
         yaw_angles,
         tilt_angles,
-        ref_tilt_cp_cts,
+        floris.farm.ref_tilt_cp_cts,
         floris.farm.pPs,
         floris.farm.pTs,
         floris.farm.turbine_fTilts,
@@ -143,7 +139,7 @@ def test_regression_tandem(sample_inputs_fixture):
         velocities,
         yaw_angles,
         tilt_angles,
-        ref_tilt_cp_cts,
+        floris.farm.ref_tilt_cp_cts,
         floris.farm.turbine_fCts,
         floris.farm.turbine_fTilts,
         floris.farm.correct_cp_ct_for_tilt,
@@ -159,7 +155,7 @@ def test_regression_tandem(sample_inputs_fixture):
         velocities,
         yaw_angles,
         tilt_angles,
-        ref_tilt_cp_cts,
+        floris.farm.ref_tilt_cp_cts,
         floris.farm.turbine_fCts,
         floris.farm.turbine_fTilts,
         floris.farm.correct_cp_ct_for_tilt,
@@ -180,7 +176,7 @@ def test_regression_tandem(sample_inputs_fixture):
             farm_axial_inductions,
         )
 
-    assert_results_arrays(test_results, baseline)
+    assert_results_arrays(test_results[0:4], baseline)
 
 
 def test_regression_rotation(sample_inputs_fixture):

--- a/tests/reg_tests/empirical_gauss_regression_test.py
+++ b/tests/reg_tests/empirical_gauss_regression_test.py
@@ -94,31 +94,31 @@ yawed_baseline = np.array(
     ]
 )
 
-yaw_added_mixing_baseline = np.array(
+yaw_added_recovery_baseline = np.array(
     [
         # 8 m/s
         [
             [7.9736330, 0.7606986, 1679924.0721706, 0.2549029],
-            [6.0012490, 0.8353654, 707912.3201655, 0.2971241],
-            [6.0404040, 0.8335607, 723777.1688957, 0.2960151],
+            [5.9343009, 0.8387850, 684615.9328740, 0.2992420],
+            [5.9680241, 0.8370593, 696314.1525222, 0.2981704],
         ],
         # 9 m/s
         [
             [8.9703371, 0.7596552, 2391434.0080674, 0.2543734],
-            [6.7531818, 0.8021893, 1027839.1215598, 0.2776204],
-            [6.8331381, 0.7989720, 1065054.4872236, 0.2758193],
+            [6.6795240, 0.8051531, 993555.3595338, 0.2792927],
+            [6.7704684, 0.8014937, 1035885.1172753, 0.2772298],
         ],
         # 10 m/s
         [
             [9.9670412, 0.7500732, 3275671.6727516, 0.2495630],
-            [7.5219271, 0.7752809, 1420639.3564230, 0.2629773],
-            [7.6244680, 0.7726302, 1482087.5389477, 0.2615835],
+            [7.4567077, 0.7772686, 1384573.5845651, 0.2640278],
+            [7.5779862, 0.7738318, 1454233.0717541, 0.2622143],
         ],
         # 11 m/s
         [
             [10.9637454, 0.7278454, 4333842.6695283, 0.2387424],
-            [8.3229921, 0.7620429, 1926896.4413586, 0.2560958],
-            [8.3952439, 0.7618461, 1976057.7564083, 0.2559949],
+            [8.2914104, 0.7621290, 1905407.7287412, 0.2561399],
+            [8.3784336, 0.7618919, 1964619.7950752, 0.2560184],
         ],
     ]
 )
@@ -203,6 +203,7 @@ def test_regression_tandem(sample_inputs_fixture):
             farm_cts,
             farm_powers,
             farm_axial_inductions,
+            max_findex_print=4
         )
 
     assert_results_arrays(test_results[0:4], baseline)
@@ -367,11 +368,12 @@ def test_regression_yaw(sample_inputs_fixture):
             farm_cts,
             farm_powers,
             farm_axial_inductions,
+            max_findex_print=4
         )
 
     assert_results_arrays(test_results[0:4], yawed_baseline)
 
-def test_regression_yaw_added_mixing(sample_inputs_fixture):
+def test_regression_yaw_added_recovery(sample_inputs_fixture):
     """
     Tandem turbines with the upstream turbine yawed and yaw added recovery
     correction enabled
@@ -381,8 +383,83 @@ def test_regression_yaw_added_mixing(sample_inputs_fixture):
     sample_inputs_fixture.floris["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
     sample_inputs_fixture.floris["wake"]["model_strings"]["turbulence_model"] = TURBULENCE_MODEL
 
-    # Turn on yaw added mixing
+    # Turn on yaw added recovery
     sample_inputs_fixture.floris["wake"]["enable_yaw_added_recovery"] = True
+    # First pass, leave at default value of 0; should then do nothing
+
+    floris = Floris.from_dict(sample_inputs_fixture.floris)
+
+    yaw_angles = np.zeros((N_FINDEX, N_TURBINES))
+    yaw_angles[:,0] = 5.0
+    floris.farm.yaw_angles = yaw_angles
+
+    floris.initialize_domain()
+    floris.steady_state_atmospheric_condition()
+
+    n_turbines = floris.farm.n_turbines
+    n_findex = floris.flow_field.n_findex
+
+    velocities = floris.flow_field.u
+    yaw_angles = floris.farm.yaw_angles
+    tilt_angles = floris.farm.tilt_angles
+    test_results = np.zeros((n_findex, n_turbines, 4))
+
+    farm_avg_velocities = average_velocity(
+        velocities,
+    )
+    farm_eff_velocities = rotor_effective_velocity(
+        floris.flow_field.air_density,
+        floris.farm.ref_density_cp_cts,
+        velocities,
+        yaw_angles,
+        tilt_angles,
+        floris.farm.ref_tilt_cp_cts,
+        floris.farm.pPs,
+        floris.farm.pTs,
+        floris.farm.turbine_fTilts,
+        floris.farm.correct_cp_ct_for_tilt,
+        floris.farm.turbine_type_map,
+    )
+    farm_cts = Ct(
+        velocities,
+        yaw_angles,
+        tilt_angles,
+        floris.farm.ref_tilt_cp_cts,
+        floris.farm.turbine_fCts,
+        floris.farm.turbine_fTilts,
+        floris.farm.correct_cp_ct_for_tilt,
+        floris.farm.turbine_type_map,
+    )
+    farm_powers = power(
+        floris.farm.ref_density_cp_cts,
+        farm_eff_velocities,
+        floris.farm.turbine_power_interps,
+        floris.farm.turbine_type_map,
+    )
+    farm_axial_inductions = axial_induction(
+        velocities,
+        yaw_angles,
+        tilt_angles,
+        floris.farm.ref_tilt_cp_cts,
+        floris.farm.turbine_fCts,
+        floris.farm.turbine_fTilts,
+        floris.farm.correct_cp_ct_for_tilt,
+        floris.farm.turbine_type_map,
+    )
+    for i in range(n_findex):
+        for j in range(n_turbines):
+            test_results[i, j, 0] = farm_avg_velocities[i, j]
+            test_results[i, j, 1] = farm_cts[i, j]
+            test_results[i, j, 2] = farm_powers[i, j]
+            test_results[i, j, 3] = farm_axial_inductions[i, j]
+
+    # Compare to case where enable_yaw_added_recovery = False, since 
+    # default gains are 0.
+    assert_results_arrays(test_results[0:4], yawed_baseline)
+
+    # Second pass, use nonzero gain
+    sample_inputs_fixture.floris["wake"]["wake_deflection_parameters"]\
+        ["empirical_gauss"]["yaw_added_mixing_gain"] = 0.1
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
 
@@ -456,9 +533,10 @@ def test_regression_yaw_added_mixing(sample_inputs_fixture):
             farm_cts,
             farm_powers,
             farm_axial_inductions,
+            max_findex_print=4
         )
     
-    assert_results_arrays(test_results[0], yaw_added_mixing_baseline)
+    assert_results_arrays(test_results[0:4], yaw_added_recovery_baseline)
 
 
 def test_regression_small_grid_rotation(sample_inputs_fixture):

--- a/tests/reg_tests/empirical_gauss_regression_test.py
+++ b/tests/reg_tests/empirical_gauss_regression_test.py
@@ -242,15 +242,15 @@ def test_regression_rotation(sample_inputs_fixture):
 
     farm_avg_velocities = average_velocity(floris.flow_field.u)
 
-    t0_270 = farm_avg_velocities[0, 0, 0]  # upstream
-    t1_270 = farm_avg_velocities[0, 0, 1]  # upstream
-    t2_270 = farm_avg_velocities[0, 0, 2]  # waked
-    t3_270 = farm_avg_velocities[0, 0, 3]  # waked
+    t0_270 = farm_avg_velocities[0, 0]  # upstream
+    t1_270 = farm_avg_velocities[0, 1]  # upstream
+    t2_270 = farm_avg_velocities[0, 2]  # waked
+    t3_270 = farm_avg_velocities[0, 3]  # waked
 
-    t0_360 = farm_avg_velocities[1, 0, 0]  # waked
-    t1_360 = farm_avg_velocities[1, 0, 1]  # upstream
-    t2_360 = farm_avg_velocities[1, 0, 2]  # waked
-    t3_360 = farm_avg_velocities[1, 0, 3]  # upstream
+    t0_360 = farm_avg_velocities[1, 0]  # waked
+    t1_360 = farm_avg_velocities[1, 1]  # upstream
+    t2_360 = farm_avg_velocities[1, 2]  # waked
+    t3_360 = farm_avg_velocities[1, 3]  # upstream
 
     assert np.allclose(t0_270, t1_360)
     assert np.allclose(t1_270, t3_360)
@@ -269,24 +269,19 @@ def test_regression_yaw(sample_inputs_fixture):
     floris = Floris.from_dict(sample_inputs_fixture.floris)
 
     yaw_angles = np.zeros((N_FINDEX, N_TURBINES))
-    yaw_angles[:,:,0] = 5.0
+    yaw_angles[:,0] = 5.0
     floris.farm.yaw_angles = yaw_angles
 
     floris.initialize_domain()
     floris.steady_state_atmospheric_condition()
 
     n_turbines = floris.farm.n_turbines
-    n_wind_speeds = floris.flow_field.n_wind_speeds
-    n_wind_directions = floris.flow_field.n_wind_directions
+    n_findex = floris.flow_field.n_findex
 
     velocities = floris.flow_field.u
     yaw_angles = floris.farm.yaw_angles
     tilt_angles = floris.farm.tilt_angles
-    ref_tilt_cp_cts = (
-        np.ones((n_wind_directions, n_wind_speeds, n_turbines))
-        * floris.farm.ref_tilt_cp_cts
-    )
-    test_results = np.zeros((n_wind_directions, n_wind_speeds, n_turbines, 4))
+    test_results = np.zeros((n_findex, n_turbines, 4))
 
     farm_avg_velocities = average_velocity(
         velocities,
@@ -297,7 +292,7 @@ def test_regression_yaw(sample_inputs_fixture):
         velocities,
         yaw_angles,
         tilt_angles,
-        ref_tilt_cp_cts,
+        floris.farm.ref_tilt_cp_cts,
         floris.farm.pPs,
         floris.farm.pTs,
         floris.farm.turbine_fTilts,
@@ -308,7 +303,7 @@ def test_regression_yaw(sample_inputs_fixture):
         velocities,
         yaw_angles,
         tilt_angles,
-        ref_tilt_cp_cts,
+        floris.farm.ref_tilt_cp_cts,
         floris.farm.turbine_fCts,
         floris.farm.turbine_fTilts,
         floris.farm.correct_cp_ct_for_tilt,
@@ -324,19 +319,18 @@ def test_regression_yaw(sample_inputs_fixture):
         velocities,
         yaw_angles,
         tilt_angles,
-        ref_tilt_cp_cts,
+        floris.farm.ref_tilt_cp_cts,
         floris.farm.turbine_fCts,
         floris.farm.turbine_fTilts,
         floris.farm.correct_cp_ct_for_tilt,
         floris.farm.turbine_type_map,
     )
-    for i in range(n_wind_directions):
-        for j in range(n_wind_speeds):
-            for k in range(n_turbines):
-                test_results[i, j, k, 0] = farm_avg_velocities[i, j, k]
-                test_results[i, j, k, 1] = farm_cts[i, j, k]
-                test_results[i, j, k, 2] = farm_powers[i, j, k]
-                test_results[i, j, k, 3] = farm_axial_inductions[i, j, k]
+    for i in range(n_findex):
+        for j in range(n_turbines):
+            test_results[i, j, 0] = farm_avg_velocities[i, j]
+            test_results[i, j, 1] = farm_cts[i, j]
+            test_results[i, j, 2] = farm_powers[i, j]
+            test_results[i, j, 3] = farm_axial_inductions[i, j]
 
     if DEBUG:
         print_test_values(
@@ -346,11 +340,16 @@ def test_regression_yaw(sample_inputs_fixture):
             farm_axial_inductions,
         )
 
-    assert_results_arrays(test_results[0], yawed_baseline)
+    assert_results_arrays(test_results[0:4], yawed_baseline)
 
 
 def test_regression_small_grid_rotation(sample_inputs_fixture):
     """
+    This utilizes a 5x5 wind farm with the layout in a regular grid oriented along the cardinal
+    directions. The wind direction in this test is from 285 degrees which is slightly north of
+    west. The objective of this test is to create a case with a very slight rotation of the wind
+    farm to target the rotation and masking routines.
+
     Where wake models are masked based on the x-location of a turbine, numerical precision
     can cause masking to fail unexpectedly. For example, in the configuration here one of
     the turbines has these delta x values;
@@ -386,7 +385,6 @@ def test_regression_small_grid_rotation(sample_inputs_fixture):
     velocities = floris.flow_field.u
     yaw_angles = floris.farm.yaw_angles
     tilt_angles = floris.farm.tilt_angles
-    ref_tilt_cp_cts = np.ones((1, 1, len(X))) * floris.farm.ref_tilt_cp_cts
 
     farm_eff_velocities = rotor_effective_velocity(
         floris.flow_field.air_density,
@@ -394,7 +392,7 @@ def test_regression_small_grid_rotation(sample_inputs_fixture):
         velocities,
         yaw_angles,
         tilt_angles,
-        ref_tilt_cp_cts,
+        floris.farm.ref_tilt_cp_cts,
         floris.farm.pPs,
         floris.farm.pTs,
         floris.farm.turbine_fTilts,
@@ -411,8 +409,8 @@ def test_regression_small_grid_rotation(sample_inputs_fixture):
     # A "column" is oriented parallel to the wind direction
     # Columns 1 - 4 should have the same power profile
     # Column 5 is completely unwaked in this model
-    assert np.allclose(farm_powers[2,0,0:5], farm_powers[2,0,5:10])
-    assert np.allclose(farm_powers[2,0,0:5], farm_powers[2,0,10:15])
-    assert np.allclose(farm_powers[2,0,0:5], farm_powers[2,0,15:20])
-    assert np.allclose(farm_powers[2,0,20], farm_powers[2,0,0])
-    assert np.allclose(farm_powers[2,0,21], farm_powers[2,0,21:25])
+    assert np.allclose(farm_powers[8,0:5], farm_powers[8,5:10])
+    assert np.allclose(farm_powers[8,0:5], farm_powers[8,10:15])
+    assert np.allclose(farm_powers[8,0:5], farm_powers[8,15:20])
+    assert np.allclose(farm_powers[8,20], farm_powers[8,0])
+    assert np.allclose(farm_powers[8,21], farm_powers[8,21:25])

--- a/tests/reg_tests/empirical_gauss_regression_test.py
+++ b/tests/reg_tests/empirical_gauss_regression_test.py
@@ -112,17 +112,16 @@ def test_regression_tandem(sample_inputs_fixture):
     floris.steady_state_atmospheric_condition()
 
     n_turbines = floris.farm.n_turbines
-    n_wind_speeds = floris.flow_field.n_wind_speeds
-    n_wind_directions = floris.flow_field.n_wind_directions
+    n_findex = floris.flow_field.n_findex
 
     velocities = floris.flow_field.u
     yaw_angles = floris.farm.yaw_angles
     tilt_angles = floris.farm.tilt_angles
     ref_tilt_cp_cts = (
-        np.ones((n_wind_directions, n_wind_speeds, n_turbines))
+        np.ones((n_findex, n_turbines))
         * floris.farm.ref_tilt_cp_cts
     )
-    test_results = np.zeros((n_wind_directions, n_wind_speeds, n_turbines, 4))
+    test_results = np.zeros((n_findex, n_turbines, 4))
 
     farm_avg_velocities = average_velocity(
         velocities,
@@ -166,13 +165,12 @@ def test_regression_tandem(sample_inputs_fixture):
         floris.farm.correct_cp_ct_for_tilt,
         floris.farm.turbine_type_map,
     )
-    for i in range(n_wind_directions):
-        for j in range(n_wind_speeds):
-            for k in range(n_turbines):
-                test_results[i, j, k, 0] = farm_avg_velocities[i, j, k]
-                test_results[i, j, k, 1] = farm_cts[i, j, k]
-                test_results[i, j, k, 2] = farm_powers[i, j, k]
-                test_results[i, j, k, 3] = farm_axial_inductions[i, j, k]
+    for i in range(n_findex):
+        for j in range(n_turbines):
+            test_results[i, j, 0] = farm_avg_velocities[i, j]
+            test_results[i, j, 1] = farm_cts[i, j]
+            test_results[i, j, 2] = farm_powers[i, j]
+            test_results[i, j, 3] = farm_axial_inductions[i, j]
 
     if DEBUG:
         print_test_values(
@@ -182,7 +180,7 @@ def test_regression_tandem(sample_inputs_fixture):
             farm_axial_inductions,
         )
 
-    assert_results_arrays(test_results[0], baseline)
+    assert_results_arrays(test_results, baseline)
 
 
 def test_regression_rotation(sample_inputs_fixture):


### PR DESCRIPTION
Ready for review.

Updating Empirical Gaussian model modules and solver call to align to 4D array structures for FLORIS v4.0.

- [X] Update tests to align with those for Jensen/Jimenez 4d tests
- [X] Update `empirical_gauss_solver()`
- [X] Update main operation of wake_deflection/empirical_gauss.py, wake_velocity/empirical_gauss.py, wake_turbulence/wake_induced_mixing.py
- [x] Add new regression test for the case when `enable_yaw_added_recovery = True`
- [x] Update `yaw_added_wake_mixing()` (in wake_deflection/empirical_gauss.py)

Passing tests?
- [x] Existing tests pass
- [x] New tests pass